### PR TITLE
Modify .gitignore for repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Ignore dump files from ALARA output
+*dump*


### PR DESCRIPTION
While dump files are useful for debugging purposes, I don't immediately see them as a necessary component of this repository. Since dump files are often created as part of a normal ALARA run, I'm modifying the existing .gitignore to exclude them from the staging area when `git add *` is executed from the command line.