### PR TITLE
Add skeleton script for populating DB

### DIFF
--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -1,10 +1,5 @@
-import alara_output_processing as aop
-import numpy as np
-import openmc
 import argparse
 import yaml
-import pandas as pd
-import sqlite3
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
fixes #5 

I'm wondering if it's overkill to import the whole openmc package here, since it's only used to access the energy boundaries of the  Vitamin-J group structure. Perhaps we could hard-code the boundaries of some commonly used group structures in a different script (the YAML file?) and import as needed.