### PR TITLE
Add function to calculate average flux with the flattening method

### DIFF
--- a/tools/calc_tirr_flux.py
+++ b/tools/calc_tirr_flux.py
@@ -1,0 +1,45 @@
+import numpy as np
+import argparse
+import sys
+import os
+
+def search_for_match(top_dict, search_str):
+    '''
+    Takes a nested top dictionary and searches all sub-dictionaries for matches with a provided string.
+    '''
+    matches = []
+    for key, value in top_dict.items():
+        if key.startswith(search_str):
+            matches.append(value)
+        elif isinstance(value, dict):
+            match_res = search_for_match(value, search_str)
+            matches.extend(match_res)
+    return matches
+
+def process_out_params(spp, lines): #imaginary lines for now
+    pulse_dict = spp.read_pulse_histories(lines)
+    sch_dict = spp.make_nested_dict(lines)
+    
+    pulse_length = search_for_match(sch_dict, "pe_dur")
+    num_pulses = search_for_match(pulse_dict, "num_pulses_all_levels")
+    dwell_time = search_for_match(pulse_dict, "delay_seconds_all_levels")
+    return pulse_length, num_pulses, dwell_time
+    
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--spp_path', '-s', required=True, help="Path (str) to folder containing sched_post_processor.py")
+    arg = parser.parse_args()
+    return arg
+
+def main():
+    arg = parse_args()
+    spp_path = arg.spp_path
+    sys.path.insert(0, spp_path)
+    import sched_post_processor as spp
+    pulse_length, num_pulses, dwell_time = process_out_params(spp, lines)
+    t_irr_flat = pulse_length * num_pulses + dwell_time * (num_pulses - 1)
+    #total flux = imaginary flux summed over all energy bins
+    avg_flux_flat = total_flux / t_irr_flat 
+
+if __name__ == "__main__":
+    main()

--- a/tools/iter_dt_out.yaml
+++ b/tools/iter_dt_out.yaml
@@ -1,6 +1,5 @@
 # List of necessary inputs from 4FPY ITER DT simulations
 
-json_filename : 'json_sch_dict_iter_dt.json'
 active_burn_time : 4 #years
 duty_cycles :
   - 1
@@ -13,4 +12,32 @@ num_pulses :
   - 8
   - 32
   - 64  
-flux_file : /filespace/a/asrajendra/research/activationDB/ref_flux_files/iter_dt_flux_2.0986E14
+flux_file : ../calc_dwell_dir/ref_flux_files/iter_dt_flux_2.0986E14
+run_dicts :
+    iter_dt_100_4y :
+        iter_dt_2p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_2p_100_4y_out
+        iter_dt_4p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_4p_100_4y_out
+        iter_dt_8p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_8p_100_4y_out
+        iter_dt_32p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_32p_100_4y_out
+        iter_dt_64p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_64p_100_4y_out
+
+    iter_dt_90_4y :
+        iter_dt_2p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_2p_90_4y_out
+        iter_dt_4p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_4p_90_4y_out    
+        iter_dt_8p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_8p_90_4y_out
+        iter_dt_32p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_32p_90_4y_out
+        iter_dt_64p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_64p_90_4y_out
+
+    iter_dt_50_4y :
+        iter_dt_2p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_2p_50_4y_out
+        iter_dt_4p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_4p_50_4y_out
+        iter_dt_8p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_8p_50_4y_out  
+        iter_dt_32p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_32p_50_4y_out  
+        iter_dt_64p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_64p_50_4y_out
+
+    iter_dt_25_4y :
+        iter_dt_2p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_2p_25_4y_out
+        iter_dt_4p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_4p_25_4y_out    
+        iter_dt_8p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_8p_25_4y_out
+        iter_dt_32p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_32p_25_4y_out
+        iter_dt_64p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_64p_25_4y_out

--- a/tools/iter_dt_out.yaml
+++ b/tools/iter_dt_out.yaml
@@ -1,5 +1,6 @@
 # List of necessary inputs from 4FPY ITER DT simulations
 
+json_filename : 'json_sch_dict_iter_dt.json'
 active_burn_time : 4 #years
 duty_cycles :
   - 1

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -5,7 +5,8 @@ import openmc
 import json
 import sys
 import os
-
+sys.path.insert(0,'../../ALARA_fork/ALARA/tools')
+import sched_post_processor as spp
 
 def search_for_match(top_dict, search_str):
     '''
@@ -23,45 +24,35 @@ def search_for_match(top_dict, search_str):
 
     return matches
 
-
-def calc_time_params_from_out(spp, run_dicts):
-    '''
-    Calculates an irradiation time array using parameters from ALARA output files.
-    It is assumed that the active burn time is constant over all runs.
-    input: 
-        run_dicts : dictionary containing sub-dictionaries organized by duty cycle, whose values are
-        dictionaries with keys = run labels organized by number of pulses, and values = paths to the
-        corresponding output file.
-    outputs:
-        active_burn_time: total amount of active irradiation time in seconds (float)
-        t_irr_arr : array of total irradiation times of shape (# duty cycles x # pulses)
-    '''
-    t_irr_arr = []
-    for run_dict in run_dicts.values():
-        for out_path in run_dict.values():
+def calc_time_params_from_out(run_dicts):
+    num_pulses = []
+    abs_dwell_times = []
+    for runs_dicts_idx, (dt_group, pulse_kv) in enumerate(run_dicts.items()):
+        for run_idx, (run_lbl, out_path) in enumerate(pulse_kv.items()):
             lines = spp.read_out(out_path)
             pulse_dict = spp.read_pulse_histories(lines)
             sch_dict = spp.make_nested_dict(lines)
-            num_pulses = eval(
-                search_for_match(pulse_dict,
-                                 'num_pulses_all_levels')[0].strip(" []"))
+
+            n_pulses = eval(search_for_match(pulse_dict, 'num_pulses_all_levels')[0].strip(" []"))
+            num_pulses.append(n_pulses)
+            
             pulse_length = search_for_match(sch_dict, 'pe_dur')[0]
-            abs_dwell_time = eval(
-                search_for_match(pulse_dict,
-                                 'delay_seconds_all_levels')[0].strip(" []"))
-            active_burn_time = num_pulses * pulse_length
-            t_irr_arr.append(active_burn_time + abs_dwell_time *
-                             (num_pulses - 1))
-    t_irr_arr = np.array(t_irr_arr).reshape(len(run_dicts.values()),
-                                            len(run_dict.values()))
-    return active_burn_time, t_irr_arr
+
+            abs_dwell_time = eval(search_for_match(pulse_dict, 'delay_seconds_all_levels')[0].strip(" []"))
+            abs_dwell_times.append(abs_dwell_time)
+            
+    # by construction, the active burn time is the same for all runs         
+    active_burn_time = pulse_length * n_pulses        
+    num_pulses = np.asarray(list(dict.fromkeys(num_pulses)))
+    abs_dwell_times = np.array(abs_dwell_times).reshape(len(run_dicts.items()), len(pulse_kv.items()))
+    t_irr_arr = active_burn_time + abs_dwell_times * (num_pulses - 1)
+    return pulse_dict, sch_dict, t_irr_arr, active_burn_time
 
 
 def open_flux_file(flux_file):
     with open(flux_file, 'r') as flux_data:
         flux_lines = flux_data.readlines()
     return flux_lines
-
 
 def parse_flux_lines(flux_lines):
     '''
@@ -82,20 +73,11 @@ def parse_flux_lines(flux_lines):
     flux_array = all_entries.reshape(num_intervals, num_groups)
     return flux_array
 
-
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--db_yaml',
-                        default="iter_dt_out.yaml",
-                        help="Path (str) to YAML containing inputs")
-    parser.add_argument(
-        '--spp_path',
-        '-sp',
-        required=True,
-        help="Path (str) to folder containing sched_post_processor.py")
+    parser.add_argument('--db_yaml', default = "iter_dt_out.yaml", help="Path (str) to YAML containing inputs")
     args = parser.parse_args()
     return args
-
 
 def read_yaml(yaml_arg):
     '''
@@ -106,31 +88,22 @@ def read_yaml(yaml_arg):
         inputs = yaml.safe_load(yaml_file)
     return inputs
 
-
 def main():
     args = parse_args()
     inputs = read_yaml(args.db_yaml)
-
-    spp_path = args.spp_path
-    sys.path.insert(0, spp_path)
-    import sched_post_processor as spp
 
     flux_file = inputs['flux_file']
     run_dicts = inputs['run_dicts']
     flux_lines = open_flux_file(flux_file)
     flux_array = parse_flux_lines(flux_lines)
 
-    active_burn_time, t_irr_arr = calc_time_params_from_out(spp, run_dicts)
+    pulse_dict, sch_dict, t_irr_arr, active_burn_time = calc_time_params_from_out(run_dicts)
 
-    total_flux = np.sum(flux_array,
-                        axis=1)  #sum over the bin widths of flux array
+    total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
     # normalize flux spectrum by the total flux in each interval
-    norm_flux_arr = flux_array / total_flux.reshape(
-        len(total_flux), 1)  # 2D array of shape num_intervals x num_groups
+    norm_flux_arr =  flux_array / total_flux.reshape(len(total_flux), 1) # 2D array of shape num_intervals x num_groups
     # for each interval, calculate flux averaged over time elapsed between the start of the 1st pulse and the end of the last
-    avg_flux_arr = np.multiply.outer(
-        total_flux, active_burn_time / t_irr_arr
-    )  # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
+    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr) # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
 
 
 if __name__ == "__main__":

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -75,7 +75,6 @@ def main():
     pulse_lengths, abs_dwell_times, t_irr_arr = calc_time_params(active_burn_time, duty_cycle_list, num_pulses)
 
     total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
-    avg_flux_arr = calc_flux_mag_flattened(total_flux, active_burn_time, t_irr_arr)
     # normalize flux spectrum by the total flux in each interval
     norm_flux_arr =  flux_array / total_flux.reshape(len(total_flux), 1) # 2D array of shape num_intervals x num_groups
     # for each interval, calculate flux averaged over time elapsed between the start of the 1st pulse and the end of the last

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -3,27 +3,51 @@ import yaml
 import numpy as np
 import openmc
 import json
+import sys
+import os
+sys.path.insert(0,'../../ALARA_fork/ALARA/tools')
+import sched_post_processor as spp
 
-def calc_time_params_from_out(sch_dict)
-
-def calc_time_params(active_burn_time, duty_cycle_list, num_pulses):
+def search_for_match(top_dict, search_str):
     '''
-    Uses provided pulsing information to determine dwell time and total irradiation time.
-    Assumes that the active irradiation time per pulse and dwell time between pulses both remain constant in any given simulation.
-    (This is always maintained for a single-level schedule and single-level pulse history.)
-
-    Iterates over the number of pulses, and for each number, calculates dwell time.
-    The duty cycle is defined as the pulse length / (pulse length + dwell time).
-    inputs:
-        active_burn_time : total active irradiation time (float) in any chosen unit
-        duty_cycle_list : list of chosen duty cycles (float)
-        num_pulses : list of number of pulses (int) that the active irradiation period is divided into
+    Takes a nested top dictionary and searches all sub-dictionaries for matches with a provided string.
     '''
-    pulse_lengths = active_burn_time / num_pulses
-    rel_dwell_times = (1 - duty_cycle_list) / duty_cycle_list
-    abs_dwell_times = np.outer(rel_dwell_times, pulse_lengths)
+    matches = []
+    for key, value in top_dict.items():
+
+        if key.startswith(search_str):
+            matches.append(value)
+
+        elif isinstance(value, dict):
+            match_res = search_for_match(value, search_str)
+            matches.extend(match_res)
+
+    return matches
+
+def calc_time_params_from_out(run_dicts):
+    num_pulses = []
+    abs_dwell_times = []
+    for runs_dicts_idx, (dt_group, pulse_kv) in enumerate(run_dicts.items()):
+        for run_idx, (run_lbl, out_path) in enumerate(pulse_kv.items()):
+            lines = spp.read_out(out_path)
+            pulse_dict = spp.read_pulse_histories(lines)
+            sch_dict = spp.make_nested_dict(lines)
+
+            n_pulses = eval(search_for_match(pulse_dict, 'num_pulses_all_levels')[0].strip(" []"))
+            num_pulses.append(n_pulses)
+            
+            pulse_length = search_for_match(sch_dict, 'pe_dur')[0]
+
+            abs_dwell_time = eval(search_for_match(pulse_dict, 'delay_seconds_all_levels')[0].strip(" []"))
+            abs_dwell_times.append(abs_dwell_time)
+            
+    # by construction, the active burn time is the same for all runs         
+    active_burn_time = pulse_length * n_pulses        
+    num_pulses = np.asarray(list(dict.fromkeys(num_pulses)))
+    abs_dwell_times = np.array(abs_dwell_times).reshape(len(run_dicts.items()), len(pulse_kv.items()))
     t_irr_arr = active_burn_time + abs_dwell_times * (num_pulses - 1)
-    return pulse_lengths, abs_dwell_times, t_irr_arr
+    return pulse_dict, sch_dict, t_irr_arr, active_burn_time
+
 
 def open_flux_file(flux_file):
     with open(flux_file, 'r') as flux_data:
@@ -38,7 +62,7 @@ def parse_flux_lines(flux_lines):
     input : flux_lines (list of lines from ALARA flux file)
     output : flux_array (numpy array of shape # intervals x number of energy groups)
     '''
-    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']           
+    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']
     all_entries = np.array(' '.join(flux_lines).split(), dtype=float)
     if len(all_entries) == 0:
         raise Exception("The chosen flux file is empty.")
@@ -64,32 +88,23 @@ def read_yaml(yaml_arg):
         inputs = yaml.safe_load(yaml_file)
     return inputs
 
-def read_json(json_filename):
-    with open(json_filename, 'r') as json_file:
-        sch_dict = json.load(json_file)
-    return sch_dict    
-
-def main():        
+def main():
     args = parse_args()
     inputs = read_yaml(args.db_yaml)
 
-    json_filename = inputs['json_filename']
-    sch_dict = read_json(json_filename)
-
-    flux_file = inputs['flux_file'] 
+    flux_file = inputs['flux_file']
+    run_dicts = inputs['run_dicts']
     flux_lines = open_flux_file(flux_file)
     flux_array = parse_flux_lines(flux_lines)
 
-    active_burn_time = np.asarray(inputs['active_burn_time'])
-    duty_cycle_list = np.asarray(inputs['duty_cycles'])
-    num_pulses = np.asarray(inputs['num_pulses'])
-    pulse_lengths, abs_dwell_times, t_irr_arr = calc_time_params(active_burn_time, duty_cycle_list, num_pulses)
+    pulse_dict, sch_dict, t_irr_arr, active_burn_time = calc_time_params_from_out(run_dicts)
 
     total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
     # normalize flux spectrum by the total flux in each interval
     norm_flux_arr =  flux_array / total_flux.reshape(len(total_flux), 1) # 2D array of shape num_intervals x num_groups
     # for each interval, calculate flux averaged over time elapsed between the start of the 1st pulse and the end of the last
     avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr) # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -2,6 +2,9 @@ import argparse
 import yaml
 import numpy as np
 import openmc
+import json
+
+def calc_time_params_from_out(sch_dict)
 
 def calc_time_params(active_burn_time, duty_cycle_list, num_pulses):
     '''
@@ -61,9 +64,17 @@ def read_yaml(yaml_arg):
         inputs = yaml.safe_load(yaml_file)
     return inputs
 
+def read_json(json_filename):
+    with open(json_filename, 'r') as json_file:
+        sch_dict = json.load(json_file)
+    return sch_dict    
+
 def main():        
     args = parse_args()
     inputs = read_yaml(args.db_yaml)
+
+    json_filename = inputs['json_filename']
+    sch_dict = read_json(json_filename)
 
     flux_file = inputs['flux_file'] 
     flux_lines = open_flux_file(flux_file)

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -7,6 +7,8 @@ def calc_time_params(active_burn_time, duty_cycle_list, num_pulses):
     '''
     Uses provided pulsing information to determine dwell time and total irradiation time.
     Assumes that the active irradiation time per pulse and dwell time between pulses both remain constant in any given simulation.
+    (This is always maintained for a single-level schedule and single-level pulse history.)
+
     Iterates over the number of pulses, and for each number, calculates dwell time.
     The duty cycle is defined as the pulse length / (pulse length + dwell time).
     inputs:

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -49,7 +49,9 @@ def calc_flux_mag_flattened(total_flux, active_burn_time, t_irr_arr):
     Calculates an average flux magnitude for each interval defined in ALARA.
     The flux is averaged over the total amount of time elapsed between the start of the first pulse and the end of the last.
     inputs:
-        total_flux : value of the flux summed over all energy bins''
+        total_flux : value of the flux summed over all energy bins
+    output:
+        avg_flux_arr : numpy array of average flux magnitudes, with shape len(total_flux) x len(duty_cycles) x len(num_pulses)    
     '''
     avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr)
     return avg_flux_arr

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -5,8 +5,7 @@ import openmc
 import json
 import sys
 import os
-sys.path.insert(0,'../../ALARA_fork/ALARA/tools')
-import sched_post_processor as spp
+
 
 def search_for_match(top_dict, search_str):
     '''
@@ -24,35 +23,45 @@ def search_for_match(top_dict, search_str):
 
     return matches
 
-def calc_time_params_from_out(run_dicts):
-    num_pulses = []
-    abs_dwell_times = []
-    for runs_dicts_idx, (dt_group, pulse_kv) in enumerate(run_dicts.items()):
-        for run_idx, (run_lbl, out_path) in enumerate(pulse_kv.items()):
+
+def calc_time_params_from_out(spp, run_dicts):
+    '''
+    Calculates an irradiation time array using parameters from ALARA output files.
+    It is assumed that the active burn time is constant over all runs.
+    input: 
+        run_dicts : dictionary containing sub-dictionaries organized by duty cycle, whose values are
+        dictionaries with keys = run labels organized by number of pulses, and values = paths to the
+        corresponding output file.
+    outputs:
+        active_burn_time: total amount of active irradiation time in seconds (float)
+        t_irr_arr : array of total irradiation times of shape (# duty cycles x # pulses)
+    '''
+    t_irr_arr = []
+    for run_dict in run_dicts.values():
+        for out_path in run_dict.values():
             lines = spp.read_out(out_path)
             pulse_dict = spp.read_pulse_histories(lines)
             sch_dict = spp.make_nested_dict(lines)
-
-            n_pulses = eval(search_for_match(pulse_dict, 'num_pulses_all_levels')[0].strip(" []"))
-            num_pulses.append(n_pulses)
-            
+            num_pulses = eval(
+                search_for_match(pulse_dict,
+                                 'num_pulses_all_levels')[0].strip(" []"))
             pulse_length = search_for_match(sch_dict, 'pe_dur')[0]
-
-            abs_dwell_time = eval(search_for_match(pulse_dict, 'delay_seconds_all_levels')[0].strip(" []"))
-            abs_dwell_times.append(abs_dwell_time)
-            
-    # by construction, the active burn time is the same for all runs         
-    active_burn_time = pulse_length * n_pulses        
-    num_pulses = np.asarray(list(dict.fromkeys(num_pulses)))
-    abs_dwell_times = np.array(abs_dwell_times).reshape(len(run_dicts.items()), len(pulse_kv.items()))
-    t_irr_arr = active_burn_time + abs_dwell_times * (num_pulses - 1)
-    return pulse_dict, sch_dict, t_irr_arr, active_burn_time
+            abs_dwell_time = eval(
+                search_for_match(pulse_dict,
+                                 'delay_seconds_all_levels')[0].strip(" []"))
+            active_burn_time = num_pulses * pulse_length
+            t_irr_arr.append(active_burn_time + abs_dwell_time *
+                             (num_pulses - 1))
+    t_irr_arr = np.array(t_irr_arr).reshape(len(run_dicts.values()),
+                                            len(run_dict.values()))
+    return active_burn_time, t_irr_arr
 
 
 def open_flux_file(flux_file):
     with open(flux_file, 'r') as flux_data:
         flux_lines = flux_data.readlines()
     return flux_lines
+
 
 def parse_flux_lines(flux_lines):
     '''
@@ -73,11 +82,20 @@ def parse_flux_lines(flux_lines):
     flux_array = all_entries.reshape(num_intervals, num_groups)
     return flux_array
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--db_yaml', default = "iter_dt_out.yaml", help="Path (str) to YAML containing inputs")
+    parser.add_argument('--db_yaml',
+                        default="iter_dt_out.yaml",
+                        help="Path (str) to YAML containing inputs")
+    parser.add_argument(
+        '--spp_path',
+        '-sp',
+        required=True,
+        help="Path (str) to folder containing sched_post_processor.py")
     args = parser.parse_args()
     return args
+
 
 def read_yaml(yaml_arg):
     '''
@@ -88,22 +106,31 @@ def read_yaml(yaml_arg):
         inputs = yaml.safe_load(yaml_file)
     return inputs
 
+
 def main():
     args = parse_args()
     inputs = read_yaml(args.db_yaml)
+
+    spp_path = args.spp_path
+    sys.path.insert(0, spp_path)
+    import sched_post_processor as spp
 
     flux_file = inputs['flux_file']
     run_dicts = inputs['run_dicts']
     flux_lines = open_flux_file(flux_file)
     flux_array = parse_flux_lines(flux_lines)
 
-    pulse_dict, sch_dict, t_irr_arr, active_burn_time = calc_time_params_from_out(run_dicts)
+    active_burn_time, t_irr_arr = calc_time_params_from_out(spp, run_dicts)
 
-    total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
+    total_flux = np.sum(flux_array,
+                        axis=1)  #sum over the bin widths of flux array
     # normalize flux spectrum by the total flux in each interval
-    norm_flux_arr =  flux_array / total_flux.reshape(len(total_flux), 1) # 2D array of shape num_intervals x num_groups
+    norm_flux_arr = flux_array / total_flux.reshape(
+        len(total_flux), 1)  # 2D array of shape num_intervals x num_groups
     # for each interval, calculate flux averaged over time elapsed between the start of the 1st pulse and the end of the last
-    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr) # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
+    avg_flux_arr = np.multiply.outer(
+        total_flux, active_burn_time / t_irr_arr
+    )  # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
 
 
 if __name__ == "__main__":

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -44,18 +44,6 @@ def parse_flux_lines(flux_lines):
     flux_array = all_entries.reshape(num_intervals, num_groups)
     return flux_array
 
-def calc_flux_mag_flattened(total_flux, active_burn_time, t_irr_arr):
-    '''
-    Calculates an average flux magnitude for each interval defined in ALARA.
-    The flux is averaged over the total amount of time elapsed between the start of the first pulse and the end of the last.
-    inputs:
-        total_flux : value of the flux summed over all energy bins
-    output:
-        avg_flux_arr : numpy array of average flux magnitudes, with shape len(total_flux) x len(duty_cycles) x len(num_pulses)    
-    '''
-    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr)
-    return avg_flux_arr
-
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--db_yaml', default = "iter_dt_out.yaml", help="Path (str) to YAML containing inputs")
@@ -88,6 +76,8 @@ def main():
     avg_flux_arr = calc_flux_mag_flattened(total_flux, active_burn_time, t_irr_arr)
     # normalize flux spectrum by the total flux in each interval
     norm_flux_arr =  flux_array / total_flux.reshape(len(total_flux), 1) # 2D array of shape num_intervals x num_groups
+    # for each interval, calculate flux averaged over time elapsed between the start of the 1st pulse and the end of the last
+    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr) # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
 
 if __name__ == "__main__":
     main()

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -3,51 +3,27 @@ import yaml
 import numpy as np
 import openmc
 import json
-import sys
-import os
-sys.path.insert(0,'../../ALARA_fork/ALARA/tools')
-import sched_post_processor as spp
 
-def search_for_match(top_dict, search_str):
+def calc_time_params_from_out(sch_dict)
+
+def calc_time_params(active_burn_time, duty_cycle_list, num_pulses):
     '''
-    Takes a nested top dictionary and searches all sub-dictionaries for matches with a provided string.
+    Uses provided pulsing information to determine dwell time and total irradiation time.
+    Assumes that the active irradiation time per pulse and dwell time between pulses both remain constant in any given simulation.
+    (This is always maintained for a single-level schedule and single-level pulse history.)
+
+    Iterates over the number of pulses, and for each number, calculates dwell time.
+    The duty cycle is defined as the pulse length / (pulse length + dwell time).
+    inputs:
+        active_burn_time : total active irradiation time (float) in any chosen unit
+        duty_cycle_list : list of chosen duty cycles (float)
+        num_pulses : list of number of pulses (int) that the active irradiation period is divided into
     '''
-    matches = []
-    for key, value in top_dict.items():
-
-        if key.startswith(search_str):
-            matches.append(value)
-
-        elif isinstance(value, dict):
-            match_res = search_for_match(value, search_str)
-            matches.extend(match_res)
-
-    return matches
-
-def calc_time_params_from_out(run_dicts):
-    num_pulses = []
-    abs_dwell_times = []
-    for runs_dicts_idx, (dt_group, pulse_kv) in enumerate(run_dicts.items()):
-        for run_idx, (run_lbl, out_path) in enumerate(pulse_kv.items()):
-            lines = spp.read_out(out_path)
-            pulse_dict = spp.read_pulse_histories(lines)
-            sch_dict = spp.make_nested_dict(lines)
-
-            n_pulses = eval(search_for_match(pulse_dict, 'num_pulses_all_levels')[0].strip(" []"))
-            num_pulses.append(n_pulses)
-            
-            pulse_length = search_for_match(sch_dict, 'pe_dur')[0]
-
-            abs_dwell_time = eval(search_for_match(pulse_dict, 'delay_seconds_all_levels')[0].strip(" []"))
-            abs_dwell_times.append(abs_dwell_time)
-            
-    # by construction, the active burn time is the same for all runs         
-    active_burn_time = pulse_length * n_pulses        
-    num_pulses = np.asarray(list(dict.fromkeys(num_pulses)))
-    abs_dwell_times = np.array(abs_dwell_times).reshape(len(run_dicts.items()), len(pulse_kv.items()))
+    pulse_lengths = active_burn_time / num_pulses
+    rel_dwell_times = (1 - duty_cycle_list) / duty_cycle_list
+    abs_dwell_times = np.outer(rel_dwell_times, pulse_lengths)
     t_irr_arr = active_burn_time + abs_dwell_times * (num_pulses - 1)
-    return pulse_dict, sch_dict, t_irr_arr, active_burn_time
-
+    return pulse_lengths, abs_dwell_times, t_irr_arr
 
 def open_flux_file(flux_file):
     with open(flux_file, 'r') as flux_data:
@@ -62,7 +38,7 @@ def parse_flux_lines(flux_lines):
     input : flux_lines (list of lines from ALARA flux file)
     output : flux_array (numpy array of shape # intervals x number of energy groups)
     '''
-    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']
+    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']           
     all_entries = np.array(' '.join(flux_lines).split(), dtype=float)
     if len(all_entries) == 0:
         raise Exception("The chosen flux file is empty.")
@@ -88,23 +64,32 @@ def read_yaml(yaml_arg):
         inputs = yaml.safe_load(yaml_file)
     return inputs
 
-def main():
+def read_json(json_filename):
+    with open(json_filename, 'r') as json_file:
+        sch_dict = json.load(json_file)
+    return sch_dict    
+
+def main():        
     args = parse_args()
     inputs = read_yaml(args.db_yaml)
 
-    flux_file = inputs['flux_file']
-    run_dicts = inputs['run_dicts']
+    json_filename = inputs['json_filename']
+    sch_dict = read_json(json_filename)
+
+    flux_file = inputs['flux_file'] 
     flux_lines = open_flux_file(flux_file)
     flux_array = parse_flux_lines(flux_lines)
 
-    pulse_dict, sch_dict, t_irr_arr, active_burn_time = calc_time_params_from_out(run_dicts)
+    active_burn_time = np.asarray(inputs['active_burn_time'])
+    duty_cycle_list = np.asarray(inputs['duty_cycles'])
+    num_pulses = np.asarray(inputs['num_pulses'])
+    pulse_lengths, abs_dwell_times, t_irr_arr = calc_time_params(active_burn_time, duty_cycle_list, num_pulses)
 
     total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
     # normalize flux spectrum by the total flux in each interval
     norm_flux_arr =  flux_array / total_flux.reshape(len(total_flux), 1) # 2D array of shape num_intervals x num_groups
     # for each interval, calculate flux averaged over time elapsed between the start of the 1st pulse and the end of the last
     avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr) # array of shape num_intervals x len(duty_cycles) x len(num_pulses)
-
 
 if __name__ == "__main__":
     main()

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -84,7 +84,7 @@ def main():
     pulse_lengths, abs_dwell_times, t_irr_arr = calc_time_params(active_burn_time, duty_cycle_list, num_pulses)
 
     total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
-    calc_flux_mag_flattened(abs_dwell_times, num_pulses, total_flux, active_burn_time)
+    avg_flux_arr = calc_flux_mag_flattened(abs_dwell_times, num_pulses, total_flux, active_burn_time)
 
 if __name__ == "__main__":
     main()

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -44,6 +44,17 @@ def parse_flux_lines(flux_lines):
     flux_array = all_entries.reshape(num_intervals, num_groups)
     return flux_array
 
+def calc_flux_mag_flattened(abs_dwell_times, num_pulses, total_flux, active_burn_time):
+    '''
+    Calculates an average flux magnitude for each interval defined in ALARA.
+    The flux is averaged over the total amount of time elapsed between the start of the first pulse and the end of the last.
+    inputs:
+        total_flux : value of the flux summed over all energy bins
+    '''
+    off_time = abs_dwell_times * (num_pulses - 1)
+    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / (active_burn_time + off_time))
+    return avg_flux_arr
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--db_yaml', default = "iter_dt_out.yaml", help="Path (str) to YAML containing inputs")
@@ -71,6 +82,9 @@ def main():
     duty_cycle_list = np.asarray(inputs['duty_cycles'])
     num_pulses = np.asarray(inputs['num_pulses'])
     pulse_lengths, abs_dwell_times, t_irr_arr = calc_time_params(active_burn_time, duty_cycle_list, num_pulses)
+
+    total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
+    calc_flux_mag_flattened(abs_dwell_times, num_pulses, total_flux, active_burn_time)
 
 if __name__ == "__main__":
     main()

--- a/tools/script_template.py
+++ b/tools/script_template.py
@@ -44,15 +44,14 @@ def parse_flux_lines(flux_lines):
     flux_array = all_entries.reshape(num_intervals, num_groups)
     return flux_array
 
-def calc_flux_mag_flattened(abs_dwell_times, num_pulses, total_flux, active_burn_time):
+def calc_flux_mag_flattened(total_flux, active_burn_time, t_irr_arr):
     '''
     Calculates an average flux magnitude for each interval defined in ALARA.
     The flux is averaged over the total amount of time elapsed between the start of the first pulse and the end of the last.
     inputs:
-        total_flux : value of the flux summed over all energy bins
+        total_flux : value of the flux summed over all energy bins''
     '''
-    off_time = abs_dwell_times * (num_pulses - 1)
-    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / (active_burn_time + off_time))
+    avg_flux_arr = np.multiply.outer(total_flux, active_burn_time / t_irr_arr)
     return avg_flux_arr
 
 def parse_args():
@@ -84,7 +83,7 @@ def main():
     pulse_lengths, abs_dwell_times, t_irr_arr = calc_time_params(active_burn_time, duty_cycle_list, num_pulses)
 
     total_flux = np.sum(flux_array, axis=1) #sum over the bin widths of flux array
-    avg_flux_arr = calc_flux_mag_flattened(abs_dwell_times, num_pulses, total_flux, active_burn_time)
+    avg_flux_arr = calc_flux_mag_flattened(total_flux, active_burn_time, t_irr_arr)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
`calc_flux_mag_flattened()` calculates and returns a 3D array of average flux magnitudes, with the first dimension being the number of ALARA intervals, the second the number of duty cycles, and the third the number of different pulses.

fixes #21