### PR TITLE
Calculate total irradiation time and flux factor for a simple schedule

### DIFF
--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -33,6 +33,12 @@ def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
         tot_ph_ff *= ff
     return tot_ph_t_irr, tot_ph_ff
 
+def read_sched_entry(pulse_length, nums_pulses, ph_dwell_times, sched_dwell_time):
+    ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
+    sched_entry_t_irr = ph_t_irr + sched_dwell_time
+    sched_entry_active_burn_time = ph_ff * ph_t_irr
+    return sched_entry_t_irr, sched_entry_active_burn_time
+
 def calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times):
     '''
     Calculate irradiation time and flux factor for a schedule that uses a single pulse history in all entries.
@@ -46,8 +52,8 @@ def calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pu
     tot_active_burn_times = 0
     tot_sched_t_irr = 0
     for pulse_length, sched_dwell_time in zip(pulse_lengths, sched_dwell_times[:-1] + [0]): # ignore last schedule entry's dwell time
-        ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
-        tot_sched_t_irr += ph_t_irr + sched_dwell_time
-        tot_active_burn_times += ph_ff * ph_t_irr
+        sched_entry_t_irr, sched_entry_active_burn_time = read_sched_entry(pulse_length, nums_pulses, ph_dwell_times, sched_dwell_time)
+        tot_sched_t_irr += sched_entry_t_irr
+        tot_active_burn_times += sched_entry_active_burn_time
     tot_sched_ff = tot_active_burn_times / tot_sched_t_irr   
     return tot_sched_t_irr, tot_sched_ff

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -12,9 +12,25 @@ def flatten_pulse_history(pulse_length, num_pulses, dwell_time):
     :param num_pulses: (int) the number of pulses
     :param dwell_time: (float) the duration of the gap between each pulse
     """
-    
     t_irr = (num_pulses-1) * (pulse_length + dwell_time) + pulse_length
     flux_factor = num_pulses * pulse_length / t_irr
 
     return t_irr, flux_factor
+
+def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
+    '''
+    Apply the flattening algorithm to all levels of a multi-level pulsing history
+    with a single-level schedule block.  
+    
+    :param pulse_lengths: active irradiation time from schedule block
+    :param nums_pulses: (iterable) number of pulses at each level
+    :param dwell_times: (iterable) the duration of the gap between each pulse at each level
+    '''
+    active_burn_time = nums_pulses[0] * pulse_length
+    tot_t_irr, ff = flatten_pulse_history(pulse_length, nums_pulses[0], dwell_times[0])
+    for num_pulses, dwell_time in zip(nums_pulses[1:], dwell_times[1:]):
+        tot_t_irr, ff = flatten_pulse_history(tot_t_irr, num_pulses, dwell_time)
+        active_burn_time = active_burn_time * num_pulses
+    tot_ff = active_burn_time / tot_t_irr    
+    return tot_t_irr, tot_ff
 

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -27,9 +27,9 @@ def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
     :param dwell_times: (iterable) the duration of the gap between each pulse at each level
     '''
     tot_ph_ff = 1
-    tot_t_irr = pulse_length
+    tot_ph_t_irr = pulse_length
     for num_pulses, dwell_time in zip(nums_pulses, dwell_times):
-        tot_ph_t_irr, ff = flatten_pulse_history(tot_t_irr, num_pulses, dwell_time)
+        tot_ph_t_irr, ff = flatten_pulse_history(tot_ph_t_irr, num_pulses, dwell_time)
         tot_ph_ff *= ff
     return tot_ph_t_irr, tot_ph_ff
 
@@ -43,10 +43,11 @@ def calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pu
     :param nums_pulses: (iterable) number of pulses at each pulsing level
     :param ph_dwell_times: (iterable) the duration of the gap between each pulse at each pulsing level
     '''
-    tot_sched_ff = 1
+    tot_active_burn_times = 0
     tot_sched_t_irr = 0
-    for pulse_length, sched_dwell_time in zip(pulse_lengths, sched_dwell_times[:-1] + [0]): # ignore last schedule dwell time
+    for pulse_length, sched_dwell_time in zip(pulse_lengths, sched_dwell_times[:-1] + [0]): # ignore last schedule entry's dwell time
         ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
         tot_sched_t_irr += ph_t_irr + sched_dwell_time
-        tot_sched_ff *= ph_ff * tot_sched_t_irr / (tot_sched_t_irr + sched_dwell_time) # check this
+        tot_active_burn_times += ph_ff * ph_t_irr
+    tot_sched_ff = tot_active_burn_times / tot_sched_t_irr   
     return tot_sched_t_irr, tot_sched_ff

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -46,12 +46,6 @@ def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
         tot_ff_flat *= ff
     return tot_t_irr_flat, tot_ff_flat
 
-def read_sched_entry(pulse_length, nums_pulses, ph_dwell_times, sched_dwell_time):
-    ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
-    sched_entry_t_irr = ph_t_irr + sched_dwell_time
-    sched_entry_active_burn_time = ph_ff * ph_t_irr
-    return sched_entry_t_irr, sched_entry_active_burn_time
-
 def flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times):
     '''
     Calculate irradiation time and flux factor for a schedule that uses a single pulse history in all entries.
@@ -65,9 +59,9 @@ def flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell
     tot_active_burn_times = 0
     tot_sched_t_irr = 0
     for pulse_length, sched_dwell_time in zip(pulse_lengths, sched_dwell_times[:-1] + [0]): # ignore last schedule entry's dwell time
-        sched_entry_t_irr, sched_entry_active_burn_time = read_sched_entry(pulse_length, nums_pulses, ph_dwell_times, sched_dwell_time)
-        tot_sched_t_irr += sched_entry_t_irr
-        tot_active_burn_times += sched_entry_active_burn_time
+        ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
+        tot_sched_t_irr += ph_t_irr + sched_dwell_time
+        tot_active_burn_times += ph_ff * ph_t_irr
     tot_sched_ff = tot_active_burn_times / tot_sched_t_irr   
     return tot_sched_t_irr, tot_sched_ff
 

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -23,12 +23,13 @@ def test_flatten_ph_levels(pulse_length, nums_pulses, dwell_times, exp_tot_tirr,
     obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, nums_pulses, dwell_times)
 
     assert obs_tot_tirr == exp_tot_tirr
-    assert obs_tot_ff == exp_tot_ff
+    assert obs_tot_ff == exp_tot_ff    
 
 @pytest.mark.parametrize( "pulse_lengths,sched_dwell_times, nums_pulses,ph_dwell_times,exp_tot_sched_tirr,exp_tot_sched_ff",
                           [
-                            ([1], [1], [1,1], [1,1], 1, 1)
-                            
+                            ([1], [1], [1,1], [1,1], 1, 1),
+                            ([2,2], [2,2], [2,2], [2,2], 30, 16/30),
+                            ([1,1], [10,10], [2,2], [1,2], 26, 8/26)
                           ])
 def test_calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times, exp_tot_sched_tirr,exp_tot_sched_ff):
     obs_tot_sched_tirr, obs_tot_sched_ff = st.calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times)

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -34,7 +34,7 @@ def test_flatten_ph_levels(pulse_length, nums_pulses, dwell_times, exp_tot_tirr,
     obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, nums_pulses, dwell_times)
 
     assert obs_tot_tirr == exp_tot_tirr
-    assert obs_tot_ff == exp_tot_ff    
+    assert obs_tot_ff == exp_tot_ff
 
 @pytest.mark.parametrize( "pulse_length,nums_pulses,exp_tot_tirr",
                           [

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -13,4 +13,16 @@ def test_single_pulse_history(pulse_length, num_pulses, dwell_time, exp_tirr, ex
     assert obs_tirr == exp_tirr
     assert obs_ff == exp_ff
 
+@pytest.mark.parametrize( "pulse_length,nums_pulses,dwell_times,exp_tot_tirr,exp_tot_ff",
+                          [
+                            (1, [1,1], [1,1], 1, 1),
+                            (1, [2,2], [1,2], 8, 4/8),
+                            (2, [1,2], [2,2], 6, 4/6)                              
+                          ])
+def test_flatten_ph_levels(pulse_length, nums_pulses, dwell_times, exp_tot_tirr, exp_tot_ff):
+    obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, nums_pulses, dwell_times)
+
+    assert obs_tot_tirr == exp_tot_tirr
+    assert obs_tot_ff == exp_tot_ff
+
 

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -54,8 +54,8 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                             ([2,2], [2,2], [2,2], [2,2], 30, 16/30),
                             ([1,1], [10,10], [2,2], [1,2], 26, 8/26)
                           ])
-def test_calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times, exp_tot_sched_tirr,exp_tot_sched_ff):
-    obs_tot_sched_tirr, obs_tot_sched_ff = st.calc_simple_sched_flattened_params(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times)
+def test_flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times, exp_tot_sched_tirr,exp_tot_sched_ff):
+    obs_tot_sched_tirr, obs_tot_sched_ff = st.flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times)
     
     assert obs_tot_sched_tirr == exp_tot_sched_tirr
     assert obs_tot_sched_ff == exp_tot_sched_ff


### PR DESCRIPTION
This new method finds the flattened time and flux parameters from a simple (no sub-schedules, single pulse history) schedule block.

addresses #23