### PR TITLE
Compress a series of simple schedules

### DIFF
--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -96,3 +96,32 @@ def compress_ph_levels(pulse_length, nums_pulses):
     for num_pulses in nums_pulses:
         tot_t_irr_comp = compress_pulse_history(tot_t_irr_comp, num_pulses)
     return tot_t_irr_comp
+
+def compress_simple_sched(pulse_lengths, nums_pulses):
+    '''
+    Calculate irradiation time for a schedule that uses a single pulse history in all entries.
+    This method does not account for sub-schedules.
+    
+    :param pulse_lengths: (iterable) of pulse lengths from the schedule entries
+    :param nums_pulses: (iterable) number of pulses at each pulsing level
+    '''
+    tot_sched_t_irr = 0
+    for pulse_length in pulse_lengths:
+        ph_t_irr = compress_ph_levels(pulse_length, nums_pulses)
+        tot_sched_t_irr += ph_t_irr
+    return tot_sched_t_irr
+
+def compress_mult_simple_scheds(all_pulse_lengths, all_nums_pulses):
+    '''
+    Calculate irradiation time for a series of schedules that each use a single pulse history in all entries.
+    A different pulse history may be used in each schedule.
+    This method does not account for sub-schedules.
+    
+    :param all_pulse_lengths: (iterable of iterables) of pulse lengths in the schedule entries, for all schedules
+    :param all_nums_pulses: (iterable of iterables) of number of pulses at each pulsing level, for all pulse histories
+    '''
+    all_sched_t_irr = 0
+    for pulse_lengths, nums_pulses in zip(all_pulse_lengths, all_nums_pulses):
+        sched_t_irr = compress_simple_sched(pulse_lengths, nums_pulses)
+        all_sched_t_irr += sched_t_irr   
+    return all_sched_t_irr

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -70,3 +70,14 @@ def test_flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_
     
     assert obs_tot_sched_tirr == exp_tot_sched_tirr
     assert obs_tot_sched_ff == exp_tot_sched_ff
+
+@pytest.mark.parametrize( "pulse_lengths,nums_pulses,exp_tot_sched_tirr",
+                          [
+                            ([1], [1,1], 1),
+                            ([2,2], [2,2], 16),
+                            ([1,1], [2,2], 8)
+                          ])
+def test_compress_simple_sched(pulse_lengths, nums_pulses, exp_tot_sched_tirr):
+    obs_tot_sched_tirr = st.compress_simple_sched(pulse_lengths, nums_pulses)
+    
+    assert obs_tot_sched_tirr == exp_tot_sched_tirr  

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -80,4 +80,15 @@ def test_flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_
 def test_compress_simple_sched(pulse_lengths, nums_pulses, exp_tot_sched_tirr):
     obs_tot_sched_tirr = st.compress_simple_sched(pulse_lengths, nums_pulses)
     
-    assert obs_tot_sched_tirr == exp_tot_sched_tirr  
+    assert obs_tot_sched_tirr == exp_tot_sched_tirr
+
+@pytest.mark.parametrize( "all_pulse_lengths, all_nums_pulses,exp_all_sched_tirr",
+                          [
+                            ([[1]], [[1,1]], 1),
+                            ([[1,2], [5,3]], [[2,2], [2,3]], 60),
+                            ([[1,2], [2,2]], [[2,2], [2,2]], 28)
+                          ])
+def test_compress_mult_simple_scheds(all_pulse_lengths, all_nums_pulses, exp_all_sched_tirr):
+    obs_all_sched_tirr = st.compress_mult_simple_scheds(all_pulse_lengths, all_nums_pulses)
+    
+    assert obs_all_sched_tirr == exp_all_sched_tirr


### PR DESCRIPTION
Analogous to the cases using the flattening approximation, but the total irradiation time is taken to be the active burn time only.

fixes #27 