### PR TITLE
Calculate irradiation time and flux factor for sub-schedule with a single pulse history

### DIFF
--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -99,13 +99,14 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
                                                child_dict['pulse_history'])
         active_burn_time += child_tirr * child_ff
         t_irr += child_tirr + child_dict['delay_dur']
-    active_burn_time = flatten_ph_levels(
-        active_burn_time,
-        [(num_pulses, 0) for num_pulses, ph_dwell_time in pulse_history])[0]
-
-    t_irr = flatten_ph_levels(t_irr, pulse_history)[0]
-
+    t_irr -= child_dicts[-1]['delay_dur'] 
     ff = active_burn_time / t_irr
+
+    t_irr, new_ff = flatten_ph_levels(
+        t_irr,
+        pulse_history)
+
+    ff *= new_ff    
 
     return t_irr, ff
 

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -94,7 +94,7 @@ def flatten_sub_sched(child_dicts,
     for child_dict in child_dicts:
         if child_dict['type'] == 'schedule':
             child_tirr, child_ff = flatten_sub_sched(
-                child_dict,
+                child_dict['children'],
                 sched_delay_dur=child_dict['sched_delay_dur'],
                 sched_np=child_dict['nums_pulses'],
                 sched_ph_dt=child_dict['ph_dwell_times'])

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -59,10 +59,10 @@ def flatten_ph_levels(pulse_length, pulse_history):
     '''
     tot_ff_flat = 1
     tot_t_irr_flat = pulse_length
-    for pulse_history_level in pulse_history:
+    for num_pulses, dwell_time in pulse_history:
         tot_t_irr_flat, ff = flatten_pulse_history(tot_t_irr_flat,
-                                                   pulse_history_level[0],
-                                                   pulse_history_level[1])
+                                                   num_pulses,
+                                                   dwell_time)
         tot_ff_flat *= ff
     return tot_t_irr_flat, tot_ff_flat
 

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -86,7 +86,6 @@ def flatten_schedule(child_dicts, pulse_history=[(1, 0)]):
      'delay_dur' : (float)
     }
     ]
-    It is possible for the value of the 'children' key at any level to consist entirely of pulse entries.
     '''
     sched_children_dur = 0
     tot_fluence = 0

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -48,7 +48,6 @@ def flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time,
     t_irr_flat_exact_pulses, ff_flat_exact_pulses = flatten_pulse_history(pulse_length, num_init_pulses, dwell_time)
     return t_irr_flat_exact_pulses, ff_flat_exact_pulses
 
-
 def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
     '''
     Apply the flattening algorithm to all levels of a multi-level pulsing history
@@ -65,64 +64,58 @@ def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
         tot_ff_flat *= ff
     return tot_t_irr_flat, tot_ff_flat
 
-def flatten_simple_sched(pulse_lengths, sched_pe_dwell_times, nums_pulses, ph_dwell_times):
+def flatten_sub_sched(child_dicts,
+                      sched_delay_dur=0,
+                      sched_np=[1],
+                      sched_ph_dt=[0]):
     '''
-    Calculate irradiation time and flux factor for a schedule that uses a single pulse history in all entries.
-    This method does not account for sub-schedules.
-    
-    :param pulse_lengths: (iterable) of pulse lengths from the schedule's pulse entries
-    :param sched_pe_dwell_times: (iterable) of dwell times from the schedule's pulse entries
-    :param nums_pulses: (iterable) number of pulses at each pulsing level
-    :param ph_dwell_times: (iterable) the duration of the gap between each pulse at each pulsing level
+    Calculate irradiation time and flux factor for a schedule containing an arbitrary number of pulse entries
+    and/or sub-schedules.
+    :param child_dicts: iterable of dictionaries, with the form:
+    {'children': [
+        {'type': 'schedule',
+        'sched_delay_dur': (float),
+        'nums_pulses': (iterable of int),
+        'ph_dwell_times': (iterable of float),
+        'children': [{...}]
+        },
+
+        {'type': 'pulse_entry',
+        'pulse_length': (float),
+        'pe_delay_dur' : (float),
+        'nums_pulses': (iterable of int),
+        'ph_dwell_times': (iterable of float)
+        }
+    ]
+    }
+    It is possible for the value of the 'children' key at any level to consist entirely of pulse entries.
     '''
-    tot_active_burn_times = 0
-    tot_sched_t_irr = 0
-    for pulse_length, sched_pe_dwell_time in zip(pulse_lengths, sched_pe_dwell_times):
-        ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
-        tot_sched_t_irr += ph_t_irr + sched_pe_dwell_time
-        tot_active_burn_times += ph_ff * ph_t_irr
-    tot_sched_ff = tot_active_burn_times / tot_sched_t_irr   
-    return tot_sched_t_irr, tot_sched_ff
-
-def flatten_sub_sched(nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays):
-    '''
-    Calculate irradiation time and flux factor for a sub-schedule with pulsing entries.
-    Uses the same pulse history in both the pulsing entries and at the schedule level.
-
-    :param nested_pls: (nested iterables) of pulse lengths, where each new iterable corresponds to the 
-    beginning of a sub-schedule
-
-    :param nested_pe_delays: (nested iterables) of delay times in each pulse entry, where each new iterable 
-    corresponds to the beginning of a sub-schedule
-
-    :param nums_pulses: (iterable) number of pulses at each pulsing level
-    :param ph_dwell_times: (iterable) the duration of the gap between each pulse at each pulsing level
-
-    :param sched_delays: Delay times from lines that designate sub-schedules. This is a recursive data structure containing nested tuples, where 
-    each tuple is of the form (current_sched_delay, child_sched_delay), and child_sched_delay is an iterable of tuples, where each tuple 
-    again has the form (current_sched_delay, child_sched_delay)
-    '''
-    current_sched_delay, child_sched_delays = sched_delays
-    sub_sched_idx = 0 # Used to decide which sub-schedule's delay should be applied when there are multiple at the same level 
     t_irr = 0
-    abt = 0
-    for nested_pl, nested_pe_delay in zip(nested_pls, nested_pe_delays):
-        if isinstance(nested_pl, list):
-            child_t_irr, child_ff = flatten_sub_sched(nested_pl, nested_pe_delay, nums_pulses, ph_dwell_times, child_sched_delays[sub_sched_idx])
-            t_irr += child_t_irr
-            abt += child_ff * child_t_irr
-            sub_sched_idx += 1
-        else:
-            pe_tirr, pe_ff = flatten_ph_levels(nested_pl, nums_pulses, ph_dwell_times)
-            t_irr += pe_tirr + nested_pe_delay
-            abt += pe_ff * pe_tirr
- 
-   
-    t_irr = flatten_simple_sched([t_irr], [0], nums_pulses, ph_dwell_times)[0] + current_sched_delay
-    abt = flatten_simple_sched([abt], [0], nums_pulses, [0]*len(ph_dwell_times))[0]
+    active_burn_time = 0
+    for child_dict in child_dicts['children']:
+        if child_dict['type'] == 'schedule':
+            child_tirr, child_ff = flatten_sub_sched(
+                child_dict,
+                sched_delay_dur=child_dict['sched_delay_dur'],
+                sched_np=child_dict['nums_pulses'],
+                sched_ph_dt=child_dict['ph_dwell_times'])
+            t_irr += child_tirr
+            active_burn_time += child_tirr * child_ff
 
-    ff = abt / t_irr
+        if child_dict['type'] == 'pulse_entry':
+            pe_tirr, pe_ff = flatten_ph_levels(child_dict['pulse_length'],
+                                               child_dict['nums_pulses'],
+                                               child_dict['ph_dwell_times'])
+            active_burn_time += pe_tirr * pe_ff
+            t_irr += pe_tirr + child_dict['pe_delay_dur']
+            
+    active_burn_time = flatten_ph_levels(active_burn_time, sched_np, [0]*len(sched_ph_dt))[0]
+    t_irr = flatten_ph_levels(t_irr, sched_np, sched_ph_dt)[0] + sched_delay_dur
+    
+    ff = active_burn_time / t_irr
+
     return t_irr, ff
+
 
 def compress_ph_levels(pulse_length, nums_pulses):
     '''

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -65,24 +65,64 @@ def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
         tot_ff_flat *= ff
     return tot_t_irr_flat, tot_ff_flat
 
-def flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times):
+def flatten_simple_sched(pulse_lengths, sched_pe_dwell_times, nums_pulses, ph_dwell_times):
     '''
     Calculate irradiation time and flux factor for a schedule that uses a single pulse history in all entries.
     This method does not account for sub-schedules.
     
-    :param pulse_lengths: (iterable) of pulse lengths from the schedule entries
-    :param sched_dwell_times: (iterable) of dwell times from the schedule entries
+    :param pulse_lengths: (iterable) of pulse lengths from the schedule's pulse entries
+    :param sched_pe_dwell_times: (iterable) of dwell times from the schedule's pulse entries
     :param nums_pulses: (iterable) number of pulses at each pulsing level
     :param ph_dwell_times: (iterable) the duration of the gap between each pulse at each pulsing level
     '''
     tot_active_burn_times = 0
     tot_sched_t_irr = 0
-    for pulse_length, sched_dwell_time in zip(pulse_lengths, sched_dwell_times[:-1] + [0]): # ignore last schedule entry's dwell time
+    for pulse_length, sched_pe_dwell_time in zip(pulse_lengths, sched_pe_dwell_times):
         ph_t_irr, ph_ff = flatten_ph_levels(pulse_length, nums_pulses, ph_dwell_times)
-        tot_sched_t_irr += ph_t_irr + sched_dwell_time
+        tot_sched_t_irr += ph_t_irr + sched_pe_dwell_time
         tot_active_burn_times += ph_ff * ph_t_irr
     tot_sched_ff = tot_active_burn_times / tot_sched_t_irr   
     return tot_sched_t_irr, tot_sched_ff
+
+def flatten_sub_sched(nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays):
+    '''
+    Calculate irradiation time and flux factor for a sub-schedule with pulsing entries.
+    Uses the same pulse history in both the pulsing entries and at the schedule level.
+
+    :param nested_pls: (nested iterables) of pulse lengths, where each new iterable corresponds to the 
+    beginning of a sub-schedule
+
+    :param nested_pe_delays: (nested iterables) of delay times in each pulse entry, where each new iterable 
+    corresponds to the beginning of a sub-schedule
+
+    :param nums_pulses: (iterable) number of pulses at each pulsing level
+    :param ph_dwell_times: (iterable) the duration of the gap between each pulse at each pulsing level
+
+    :param sched_delays: Delay times from lines that designate sub-schedules. This is a recursive data structure containing nested tuples, where 
+    each tuple is of the form (current_sched_delay, child_sched_delay), and child_sched_delay is an iterable of tuples, where each tuple 
+    again has the form (current_sched_delay, child_sched_delay)
+    '''
+    current_sched_delay, child_sched_delays = sched_delays
+    sub_sched_idx = 0 # Used to decide which sub-schedule's delay should be applied when there are multiple at the same level 
+    t_irr = 0
+    abt = 0
+    for nested_pl, nested_pe_delay in zip(nested_pls, nested_pe_delays):
+        if isinstance(nested_pl, list):
+            child_t_irr, child_ff = flatten_sub_sched(nested_pl, nested_pe_delay, nums_pulses, ph_dwell_times, child_sched_delays[sub_sched_idx])
+            t_irr += child_t_irr
+            abt += child_ff * child_t_irr
+            sub_sched_idx += 1
+        else:
+            pe_tirr, pe_ff = flatten_ph_levels(nested_pl, nums_pulses, ph_dwell_times)
+            t_irr += pe_tirr + nested_pe_delay
+            abt += pe_ff * pe_tirr
+ 
+   
+    t_irr = flatten_simple_sched([t_irr], [0], nums_pulses, ph_dwell_times)[0] + current_sched_delay
+    abt = flatten_simple_sched([abt], [0], nums_pulses, [0]*len(ph_dwell_times))[0]
+
+    ff = abt / t_irr
+    return t_irr, ff
 
 def compress_ph_levels(pulse_length, nums_pulses):
     '''

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -48,44 +48,43 @@ def flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time,
     t_irr_flat_exact_pulses, ff_flat_exact_pulses = flatten_pulse_history(pulse_length, num_init_pulses, dwell_time)
     return t_irr_flat_exact_pulses, ff_flat_exact_pulses
 
-def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
+
+def flatten_ph_levels(pulse_length, pulse_history):
     '''
     Apply the flattening algorithm to all levels of a multi-level pulsing history
     with a single-level schedule block.  
     
-    :param pulse_lengths: active irradiation time from schedule block
-    :param nums_pulses: (iterable) number of pulses at each level
-    :param dwell_times: (iterable) the duration of the gap between each pulse at each level
+    :param pulse_length: active irradiation time from schedule block
+    :param pulse_history : (iterable of (int, float))
     '''
     tot_ff_flat = 1
     tot_t_irr_flat = pulse_length
-    for num_pulses, dwell_time in zip(nums_pulses, dwell_times):
-        tot_t_irr_flat, ff = flatten_pulse_history(tot_t_irr_flat, num_pulses, dwell_time)
+    for pulse_history_level in pulse_history:
+        tot_t_irr_flat, ff = flatten_pulse_history(tot_t_irr_flat,
+                                                   pulse_history_level[0],
+                                                   pulse_history_level[1])
         tot_ff_flat *= ff
     return tot_t_irr_flat, tot_ff_flat
 
-def flatten_sub_sched(child_dicts,
-                      pulse_history=[(1,0)],
-                      delay=0):
+
+def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)], sched_delay_dur=0):
     '''
     Calculate irradiation time and flux factor for a schedule containing an arbitrary number of pulse entries
     and/or sub-schedules.
     :param child_dicts: iterable of dictionaries, with the form:
-   [
-        {'type': 'schedule',
-        'sched_delay_dur': (float),
-        'pulse_history': (iterable of (int, float)),
-        'children': [{...}]
-        },
+    [
+    {'type': 'schedule',
+    'pulse_history': (iterable of (int, float)),
+    'sched_delay_dur': (float),
+    'children': [{...}]
+    },
 
-        {'type': 'pulse_entry',
-        'pulse_length': (float),
-        'pe_delay_dur' : (float),
-        'nums_pulses': (iterable of int),
-        'ph_dwell_times': (iterable of float)
-        }
-    ]
+    {'type': 'pulse_entry',
+    'pulse_length': (float),
+    'pulse_history': (iterable of (int, float)),
+    'pe_delay_dur' : (float)
     }
+    ]
     It is possible for the value of the 'children' key at any level to consist entirely of pulse entries.
     '''
     t_irr = 0
@@ -94,25 +93,27 @@ def flatten_sub_sched(child_dicts,
         if child_dict['type'] == 'schedule':
             child_tirr, child_ff = flatten_sub_sched(
                 child_dict['children'],
-                sched_delay_dur=child_dict['sched_delay_dur'],
-                sched_np=child_dict['nums_pulses'],
-                sched_ph_dt=child_dict['ph_dwell_times'])
+                pulse_history=child_dict['pulse_history'],
+                sched_delay_dur=child_dict['sched_delay_dur'])
             t_irr += child_tirr + child_dict['sched_delay_dur']
             active_burn_time += child_tirr * child_ff
 
         if child_dict['type'] == 'pulse_entry':
             pe_tirr, pe_ff = flatten_ph_levels(child_dict['pulse_length'],
-                                               child_dict['nums_pulses'],
-                                               child_dict['ph_dwell_times'])
+                                               child_dict['pulse_history'])
             active_burn_time += pe_tirr * pe_ff
             t_irr += pe_tirr + child_dict['pe_delay_dur']
-            
-    active_burn_time = flatten_ph_levels(active_burn_time, sched_np, [0]*len(sched_ph_dt))[0]
-    t_irr = flatten_ph_levels(t_irr, sched_np, sched_ph_dt)[0]
-    
+
+    active_burn_time = flatten_ph_levels(
+        active_burn_time,
+        [(num_pulses, 0) for num_pulses, ph_dwell_time in pulse_history])[0]
+
+    t_irr = flatten_ph_levels(t_irr, pulse_history)[0]
+
     ff = active_burn_time / t_irr
 
     return t_irr, ff
+
 
 def compress_ph_levels(pulse_length, nums_pulses):
     '''

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -67,7 +67,7 @@ def flatten_ph_levels(pulse_length, pulse_history):
     return tot_t_irr_flat, tot_ff_flat
 
 
-def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)], sched_delay_dur=0):
+def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
     '''
     Calculate irradiation time and flux factor for a schedule containing an arbitrary number of pulse entries
     and/or sub-schedules.
@@ -93,8 +93,7 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)], sched_delay_dur=0):
         if child_dict['type'] == 'schedule':
             child_tirr, child_ff = flatten_sub_sched(
                 child_dict['children'],
-                pulse_history=child_dict['pulse_history'],
-                sched_delay_dur=child_dict['sched_delay_dur'])
+                pulse_history=child_dict['pulse_history'])
             t_irr += child_tirr + child_dict['sched_delay_dur']
             active_burn_time += child_tirr * child_ff
 

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -93,7 +93,7 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
         if child_dict['type'] == 'schedule':
             child_tirr, child_ff = flatten_sub_sched(
                 child_dict['children'],
-                pulse_history=child_dict['pulse_history'])
+                child_dict['pulse_history'])
         if child_dict['type'] == 'pulse_entry':
             child_tirr, child_ff = flatten_ph_levels(child_dict['pulse_length'],
                                                child_dict['pulse_history'])

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -75,7 +75,7 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
     [
     {'type': 'schedule',
     'pulse_history': (iterable of (int, float)),
-    'sched_delay_dur': (float),
+    'delay_dur': (float),
     'children': [{...}]
     },
 
@@ -94,7 +94,7 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
             child_tirr, child_ff = flatten_sub_sched(
                 child_dict['children'],
                 pulse_history=child_dict['pulse_history'])
-            t_irr += child_tirr + child_dict['sched_delay_dur']
+            t_irr += child_tirr + child_dict['delay_dur']
             active_burn_time += child_tirr * child_ff
 
         if child_dict['type'] == 'pulse_entry':

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -74,15 +74,15 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
     :param child_dicts: iterable of dictionaries, with the form:
     [
     {'type': 'schedule',
-    'pulse_history': (iterable of (int, float)),
-    'delay_dur': (float),
-    'children': [{...}]
+     'children': [{...}]
+     'pulse_history': (iterable of (int, float)),
+     'delay_dur': (float),
     },
 
     {'type': 'pulse_entry',
-    'pulse_length': (float),
-    'pulse_history': (iterable of (int, float)),
-    'delay_dur' : (float)
+     'pulse_length': (float),
+     'pulse_history': (iterable of (int, float)),
+     'delay_dur' : (float)
     }
     ]
     It is possible for the value of the 'children' key at any level to consist entirely of pulse entries.

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -65,9 +65,8 @@ def flatten_ph_levels(pulse_length, nums_pulses, dwell_times):
     return tot_t_irr_flat, tot_ff_flat
 
 def flatten_sub_sched(child_dicts,
-                      sched_delay_dur=0,
-                      sched_np=[1],
-                      sched_ph_dt=[0]):
+                      pulse_history=[(1,0)],
+                      delay=0):
     '''
     Calculate irradiation time and flux factor for a schedule containing an arbitrary number of pulse entries
     and/or sub-schedules.

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -72,7 +72,7 @@ def flatten_sub_sched(child_dicts,
     Calculate irradiation time and flux factor for a schedule containing an arbitrary number of pulse entries
     and/or sub-schedules.
     :param child_dicts: iterable of dictionaries, with the form:
-    {'children': [
+   [
         {'type': 'schedule',
         'sched_delay_dur': (float),
         'nums_pulses': (iterable of int),

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -91,7 +91,7 @@ def flatten_sub_sched(child_dicts,
     '''
     t_irr = 0
     active_burn_time = 0
-    for child_dict in child_dicts['children']:
+    for child_dict in child_dicts:
         if child_dict['type'] == 'schedule':
             child_tirr, child_ff = flatten_sub_sched(
                 child_dict,

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -67,7 +67,7 @@ def flatten_ph_levels(pulse_length, pulse_history):
     return tot_t_irr_flat, tot_ff_flat
 
 
-def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
+def flatten_schedule(child_dicts, pulse_history=[(1, 0)]):
     '''
     Calculate irradiation time and flux factor for a schedule containing an arbitrary number of pulse entries
     and/or sub-schedules.

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -82,7 +82,7 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
     {'type': 'pulse_entry',
     'pulse_length': (float),
     'pulse_history': (iterable of (int, float)),
-    'pe_delay_dur' : (float)
+    'delay_dur' : (float)
     }
     ]
     It is possible for the value of the 'children' key at any level to consist entirely of pulse entries.
@@ -101,7 +101,7 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
             pe_tirr, pe_ff = flatten_ph_levels(child_dict['pulse_length'],
                                                child_dict['pulse_history'])
             active_burn_time += pe_tirr * pe_ff
-            t_irr += pe_tirr + child_dict['pe_delay_dur']
+            t_irr += pe_tirr + child_dict['delay_dur']
 
     active_burn_time = flatten_ph_levels(
         active_burn_time,

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -99,7 +99,7 @@ def flatten_sub_sched(child_dicts,
                 sched_delay_dur=child_dict['sched_delay_dur'],
                 sched_np=child_dict['nums_pulses'],
                 sched_ph_dt=child_dict['ph_dwell_times'])
-            t_irr += child_tirr
+            t_irr += child_tirr + child_dict['sched_delay_dur']
             active_burn_time += child_tirr * child_ff
 
         if child_dict['type'] == 'pulse_entry':
@@ -110,7 +110,7 @@ def flatten_sub_sched(child_dicts,
             t_irr += pe_tirr + child_dict['pe_delay_dur']
             
     active_burn_time = flatten_ph_levels(active_burn_time, sched_np, [0]*len(sched_ph_dt))[0]
-    t_irr = flatten_ph_levels(t_irr, sched_np, sched_ph_dt)[0] + sched_delay_dur
+    t_irr = flatten_ph_levels(t_irr, sched_np, sched_ph_dt)[0]
     
     ff = active_burn_time / t_irr
 

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -94,15 +94,11 @@ def flatten_sub_sched(child_dicts, pulse_history=[(1, 0)]):
             child_tirr, child_ff = flatten_sub_sched(
                 child_dict['children'],
                 pulse_history=child_dict['pulse_history'])
-            t_irr += child_tirr + child_dict['delay_dur']
-            active_burn_time += child_tirr * child_ff
-
         if child_dict['type'] == 'pulse_entry':
-            pe_tirr, pe_ff = flatten_ph_levels(child_dict['pulse_length'],
+            child_tirr, child_ff = flatten_ph_levels(child_dict['pulse_length'],
                                                child_dict['pulse_history'])
-            active_burn_time += pe_tirr * pe_ff
-            t_irr += pe_tirr + child_dict['delay_dur']
-
+        active_burn_time += child_tirr * child_ff
+        t_irr += child_tirr + child_dict['delay_dur']
     active_burn_time = flatten_ph_levels(
         active_burn_time,
         [(num_pulses, 0) for num_pulses, ph_dwell_time in pulse_history])[0]

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -12,10 +12,10 @@ def flatten_pulse_history(pulse_length, num_pulses, dwell_time):
     :param num_pulses: (int) the number of pulses
     :param dwell_time: (float) the duration of the gap between each pulse
     """
-    t_irr_flat = (num_pulses-1) * (pulse_length + dwell_time) + pulse_length
-    flux_factor_flat = num_pulses * pulse_length / t_irr_flat
+    duration_flat = (num_pulses-1) * (pulse_length + dwell_time) + pulse_length
+    fluence_flat = num_pulses * pulse_length
 
-    return t_irr_flat, flux_factor_flat
+    return duration_flat, fluence_flat
 
 def compress_pulse_history(pulse_length, num_pulses):
     '''
@@ -26,9 +26,9 @@ def compress_pulse_history(pulse_length, num_pulses):
     :param pulse_length: (float) the duration of each pulse
     :param num_pulses: (int) the number of pulses
     '''
-    t_irr_comp = num_pulses * pulse_length
+    sched_children_dur_comp = num_pulses * pulse_length
 
-    return t_irr_comp
+    return sched_children_dur_comp
 
 
 def flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time,
@@ -45,8 +45,8 @@ def flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time,
     :param num_final_pulses: (int) the number of final pulses
     '''
     num_init_pulses = num_tot_pulses - num_final_pulses
-    t_irr_flat_exact_pulses, ff_flat_exact_pulses = flatten_pulse_history(pulse_length, num_init_pulses, dwell_time)
-    return t_irr_flat_exact_pulses, ff_flat_exact_pulses
+    sched_children_dur_flat_exact_pulses, fluence_flat_exact_pulses = flatten_pulse_history(pulse_length, num_init_pulses, dwell_time)
+    return sched_children_dur_flat_exact_pulses, fluence_flat_exact_pulses
 
 
 def flatten_ph_levels(pulse_length, pulse_history):
@@ -58,13 +58,14 @@ def flatten_ph_levels(pulse_length, pulse_history):
     :param pulse_history : (iterable of (int, float))
     '''
     tot_ff_flat = 1
-    tot_t_irr_flat = pulse_length
+    tot_dur_flat = pulse_length
     for num_pulses, dwell_time in pulse_history:
-        tot_t_irr_flat, ff = flatten_pulse_history(tot_t_irr_flat,
+        tot_dur_flat, fluence_flat = flatten_pulse_history(tot_dur_flat,
                                                    num_pulses,
                                                    dwell_time)
-        tot_ff_flat *= ff
-    return tot_t_irr_flat, tot_ff_flat
+        tot_ff_flat *= fluence_flat / tot_dur_flat
+    tot_fluence_flat = tot_dur_flat * tot_ff_flat   
+    return tot_dur_flat, tot_fluence_flat
 
 
 def flatten_schedule(child_dicts, pulse_history=[(1, 0)]):
@@ -87,28 +88,27 @@ def flatten_schedule(child_dicts, pulse_history=[(1, 0)]):
     ]
     It is possible for the value of the 'children' key at any level to consist entirely of pulse entries.
     '''
-    t_irr = 0
-    active_burn_time = 0
+    sched_children_dur = 0
+    tot_fluence = 0
     for child_dict in child_dicts:
         if child_dict['type'] == 'schedule':
-            child_tirr, child_ff = flatten_schedule(
+            child_dur, child_fluence = flatten_schedule(
                 child_dict['children'],
                 child_dict['pulse_history'])
         if child_dict['type'] == 'pulse_entry':
-            child_tirr, child_ff = flatten_ph_levels(child_dict['pulse_length'],
+            child_dur, child_fluence = flatten_ph_levels(child_dict['pulse_length'],
                                                child_dict['pulse_history'])
-        active_burn_time += child_tirr * child_ff
-        t_irr += child_tirr + child_dict['delay_dur']
-    t_irr -= child_dicts[-1]['delay_dur'] 
-    ff = active_burn_time / t_irr
+        tot_fluence += child_fluence
+        sched_children_dur += child_dur + child_dict['delay_dur']
+    sched_children_dur -= child_dicts[-1]['delay_dur']
 
-    t_irr, new_ff = flatten_ph_levels(
-        t_irr,
+    sched_dur, new_fluence = flatten_ph_levels(
+        sched_children_dur,
         pulse_history)
 
-    ff *= new_ff    
+    tot_fluence *= new_fluence / sched_children_dur
 
-    return t_irr, ff
+    return sched_dur, tot_fluence
 
 
 def compress_ph_levels(pulse_length, nums_pulses):
@@ -119,7 +119,7 @@ def compress_ph_levels(pulse_length, nums_pulses):
     :param pulse_lengths: active irradiation time from schedule block
     :param nums_pulses: (iterable) number of pulses at each level
     '''
-    tot_t_irr_comp = pulse_length
+    tot_sched_children_dur_comp = pulse_length
     for num_pulses in nums_pulses:
-        tot_t_irr_comp = compress_pulse_history(tot_t_irr_comp, num_pulses)
-    return tot_t_irr_comp
+        tot_sched_children_dur_comp = compress_pulse_history(tot_sched_children_dur_comp, num_pulses)
+    return tot_sched_children_dur_comp

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -75,8 +75,7 @@ def flatten_sub_sched(child_dicts,
    [
         {'type': 'schedule',
         'sched_delay_dur': (float),
-        'nums_pulses': (iterable of int),
-        'ph_dwell_times': (iterable of float),
+        'pulse_history': (iterable of (int, float)),
         'children': [{...}]
         },
 

--- a/tools/schedule_transforms.py
+++ b/tools/schedule_transforms.py
@@ -91,7 +91,7 @@ def flatten_schedule(child_dicts, pulse_history=[(1, 0)]):
     active_burn_time = 0
     for child_dict in child_dicts:
         if child_dict['type'] == 'schedule':
-            child_tirr, child_ff = flatten_sub_sched(
+            child_tirr, child_ff = flatten_schedule(
                 child_dict['children'],
                 child_dict['pulse_history'])
         if child_dict['type'] == 'pulse_entry':

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -158,6 +158,39 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                4,
                                4/4),
 
+                            ([
+                                {
+                                'type': 'schedule',
+                                'delay_dur': 1,
+                                'pulse_history': [(2,0)],
+                                'children':
+                                    [
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 1,
+                                    'pulse_history': [(2,0)],
+                                    'delay_dur' : 1
+                                    }
+                                    ],
+                                },
+                                {   
+                                'type': 'schedule',
+                                'delay_dur': 1,
+                                'pulse_history': [(2,0)],
+                                'children':
+                                    [
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 1,
+                                    'pulse_history': [(2,0)],
+                                    'delay_dur' : 1
+                                    }
+                                    ],
+                                },
+                               ],
+
+                               [(1,0)],
+                               9,
+                               8/9),
+
                           ])
 def test_flatten_sub_sched(child_dicts, pulse_history,
                            exp_tirr, exp_ff):

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -61,12 +61,26 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
 @pytest.mark.parametrize( "pulse_lengths,sched_dwell_times, nums_pulses,ph_dwell_times,exp_tot_sched_tirr,exp_tot_sched_ff",
                           [
-                            ([1], [1], [1,1], [1,1], 1, 1),
-                            ([2,2], [2,2], [2,2], [2,2], 30, 16/30),
-                            ([1,1], [10,10], [2,2], [1,2], 26, 8/26)
+                            ([1], [0], [1,1], [1,1], 1, 1),
+                            ([2,2], [2,0], [2,2], [2,2], 30, 16/30),
+                            ([1,1], [10,0], [2,2], [1,2], 26, 8/26)
                           ])
 def test_flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times, exp_tot_sched_tirr,exp_tot_sched_ff):
     obs_tot_sched_tirr, obs_tot_sched_ff = st.flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times)
     
     assert obs_tot_sched_tirr == exp_tot_sched_tirr
     assert obs_tot_sched_ff == exp_tot_sched_ff
+
+@pytest.mark.parametrize( "nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays, exp_tirr, exp_ff",
+                          [
+                            ([1,1], [1, 1], [1], [1], (1, []), 5, 2/5),
+                            ([10,2,[5]], [20, 10, [10]], [1], [1], (5, [(2, [])]), 64, 17/64),
+                            ([10,2,[5],[5]], [20, 10, [10],[3]], [1], [1], (5, [(2, []), (2, [])]), 74, 22/74),
+                            ([10,2,[5],4], [20, 10, [10],20], [1], [1], (5, [(2, [])]), 88, 21/88),
+                            ([1], [1], [2], [0], (1, []), 7, 4/7)
+                          ])
+def test_flatten_sub_sched(nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays, exp_tirr, exp_ff):
+    obs_tirr, obs_ff = st.flatten_sub_sched(nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays)
+    
+    assert obs_tirr == exp_tirr
+    assert obs_ff == exp_ff    

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -5,7 +5,7 @@ import schedule_transforms as st
                           [
                             (1, 1, 1, 1, 1),
                             (1, 2, 1, 3, 2/3),
-                            (2, 4, 6, 26, 8/26)                              
+                            (2, 4, 6, 26, 8/26)
                           ])
 def test_single_pulse_history(pulse_length, num_pulses, dwell_time, exp_tirr, exp_ff):
     obs_tirr, obs_ff = st.flatten_pulse_history(pulse_length, num_pulses, dwell_time)
@@ -17,7 +17,7 @@ def test_single_pulse_history(pulse_length, num_pulses, dwell_time, exp_tirr, ex
                           [
                             (1, 5, 2, 1, 10, 4/10),
                             (5, 5, 1, 1, 23, 20/23),
-                            (5, 5, 1, 3, 11, 10/11)                              
+                            (5, 5, 1, 3, 11, 10/11)
                           ])
 def test_flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_final_pulses, exp_tirr, exp_ff):
     obs_tirr, obs_ff = st.flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_final_pulses)
@@ -28,7 +28,7 @@ def test_flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_f
                           [
                             (1, 1, 1),
                             (1, 2, 2),
-                            (10, 5, 50)                              
+                            (10, 5, 50)
                           ])
 def test_compress_pulse_history(pulse_length, num_pulses, exp_tirr):
     obs_tirr = st.compress_pulse_history(pulse_length, num_pulses)
@@ -39,7 +39,7 @@ def test_compress_pulse_history(pulse_length, num_pulses, exp_tirr):
                           [
                             (1, [1,1], [1,1], 1, 1),
                             (1, [2,2], [1,2], 8, 4/8),
-                            (2, [1,2], [2,2], 6, 4/6)                              
+                            (2, [1,2], [2,2], 6, 4/6)
                           ])
 def test_flatten_ph_levels(pulse_length, nums_pulses, dwell_times, exp_tot_tirr, exp_tot_ff):
     obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, nums_pulses, dwell_times)
@@ -51,7 +51,7 @@ def test_flatten_ph_levels(pulse_length, nums_pulses, dwell_times, exp_tot_tirr,
                           [
                             (1, [1,1], 1),
                             (1, [2,2], 4),
-                            (2, [5,7], 70)                              
+                            (2, [5,7], 70)
                           ])
 def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
     obs_tot_tirr = st.compress_ph_levels(pulse_length, nums_pulses)
@@ -59,28 +59,126 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
     assert obs_tot_tirr == exp_tot_tirr
 
 
-@pytest.mark.parametrize( "pulse_lengths,sched_dwell_times, nums_pulses,ph_dwell_times,exp_tot_sched_tirr,exp_tot_sched_ff",
+@pytest.mark.parametrize( "child_dicts, sched_delay_dur, sched_np, sched_ph_dt, exp_tirr, exp_ff",
                           [
-                            ([1], [0], [1,1], [1,1], 1, 1),
-                            ([2,2], [2,0], [2,2], [2,2], 30, 16/30),
-                            ([1,1], [10,0], [2,2], [1,2], 26, 8/26)
-                          ])
-def test_flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times, exp_tot_sched_tirr,exp_tot_sched_ff):
-    obs_tot_sched_tirr, obs_tot_sched_ff = st.flatten_simple_sched(pulse_lengths, sched_dwell_times, nums_pulses, ph_dwell_times)
-    
-    assert obs_tot_sched_tirr == exp_tot_sched_tirr
-    assert obs_tot_sched_ff == exp_tot_sched_ff
+                            ({'children':
+                              [{
+                                'type': 'schedule',
+                                'sched_delay_dur': 1,
+                                'nums_pulses': [1],
+                                'ph_dwell_times':[1],
+                                'children':
+                                    [
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 1,
+                                    'pe_delay_dur' : 1,
+                                    'nums_pulses': [1],
+                                    'ph_dwell_times': [1]},
 
-@pytest.mark.parametrize( "nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays, exp_tirr, exp_ff",
-                          [
-                            ([1,1], [1, 1], [1], [1], (1, []), 5, 2/5),
-                            ([10,2,[5]], [20, 10, [10]], [1], [1], (5, [(2, [])]), 64, 17/64),
-                            ([10,2,[5],[5]], [20, 10, [10],[3]], [1], [1], (5, [(2, []), (2, [])]), 74, 22/74),
-                            ([10,2,[5],4], [20, 10, [10],20], [1], [1], (5, [(2, [])]), 88, 21/88),
-                            ([1], [1], [2], [0], (1, []), 7, 4/7)
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 1,
+                                    'pe_delay_dur' : 1,
+                                    'nums_pulses': [1],
+                                    'ph_dwell_times': [1]}
+                                    ]},
+                               ]
+                               },
+
+                               0,
+                               [1],
+                               [0],
+                               5,
+                               2/5),
+
+                            ({'children':
+                              [
+                                {
+                                'type': 'schedule',
+                                'sched_delay_dur': 5,
+                                'nums_pulses': [1],
+                                'ph_dwell_times':[1],
+                                'children':
+                                    [
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 10,
+                                    'pe_delay_dur' : 20,
+                                    'nums_pulses': [1],
+                                    'ph_dwell_times': [1]},
+
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 2,
+                                    'pe_delay_dur' : 10,
+                                    'nums_pulses': [1],
+                                    'ph_dwell_times': [1]},
+
+                                    {'type': 'schedule',
+                                    'sched_delay_dur': 2,
+                                    'nums_pulses': [1],
+                                    'ph_dwell_times': [1],
+                                    'children':
+                                        [
+                                        {'type': 'pulse_entry',
+                                        'pulse_length': 5,
+                                        'pe_delay_dur' : 10,
+                                        'nums_pulses': [1],
+                                        'ph_dwell_times': [1]
+                                        }
+                                        ]
+                                    },
+                                    {'type': 'schedule',
+                                    'sched_delay_dur': 2,
+                                    'nums_pulses': [1],
+                                    'ph_dwell_times': [1],
+                                    'children':
+                                        [
+                                        {'type': 'pulse_entry',
+                                        'pulse_length': 5,
+                                        'pe_delay_dur' : 3,
+                                        'nums_pulses': [1],
+                                        'ph_dwell_times': [1]
+                                        }
+                                        ]
+                                    }
+
+                                    ]
+                                },
+                               ]
+                               },
+
+                               0,
+                               [1],
+                               [0],
+                               74,
+                               22/74),
+
+                            ({'children':
+                              [{
+                                'type': 'schedule',
+                                'sched_delay_dur': 1,
+                                'nums_pulses': [2],
+                                'ph_dwell_times':[0],
+                                'children':
+                                    [
+                                    {'type': 'pulse_entry',
+                                    'pulse_length': 1,
+                                    'pe_delay_dur' : 1,
+                                    'nums_pulses': [2],
+                                    'ph_dwell_times': [0]}
+                                    ]},
+                               ]
+                               },
+
+                               0,
+                               [1],
+                               [0],
+                               7,
+                               4/7),
+
                           ])
-def test_flatten_sub_sched(nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays, exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_sub_sched(nested_pls, nested_pe_delays, nums_pulses, ph_dwell_times, sched_delays)
-    
+def test_flatten_sub_sched(child_dicts, sched_delay_dur, sched_np, sched_ph_dt,
+                           exp_tirr, exp_ff):
+    obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, sched_delay_dur,
+                                            sched_np, sched_ph_dt)
+
     assert obs_tirr == exp_tirr
-    assert obs_ff == exp_ff    
+    assert obs_ff == exp_ff

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -70,13 +70,13 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                     {'type': 'pulse_entry',
                                     'pulse_length': 1,
                                     'pulse_history':[(1,1)],
-                                    'pe_delay_dur' : 1
+                                    'delay_dur' : 1
                                     },
 
                                     {'type': 'pulse_entry',
                                     'pulse_length': 1,
                                     'pulse_history':[(1,1)],
-                                    'pe_delay_dur' : 1
+                                    'delay_dur' : 1
                                     }
                                     ]
                                }
@@ -96,13 +96,13 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                     {'type': 'pulse_entry',
                                     'pulse_length': 10,
                                     'pulse_history':[(1,1)],
-                                    'pe_delay_dur' : 20
+                                    'delay_dur' : 20
                                     },
 
                                     {'type': 'pulse_entry',
                                     'pulse_length': 2,
                                     'pulse_history':[(1,1)],
-                                    'pe_delay_dur' : 10
+                                    'delay_dur' : 10
                                     },
 
                                     {'type': 'schedule',
@@ -113,7 +113,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                         {'type': 'pulse_entry',
                                         'pulse_length': 5,
                                         'pulse_history':[(1,1)],
-                                        'pe_delay_dur' : 10
+                                        'delay_dur' : 10
                                         }
                                         ]
                                     },
@@ -125,7 +125,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                         {'type': 'pulse_entry',
                                         'pulse_length': 5,
                                         'pulse_history':[(1,1)],
-                                        'pe_delay_dur' : 3
+                                        'delay_dur' : 3
                                         }
                                         ]
                                     }
@@ -148,7 +148,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                     {'type': 'pulse_entry',
                                     'pulse_length': 1,
                                     'pulse_history': [(2,0)],
-                                    'pe_delay_dur' : 1
+                                    'delay_dur' : 1
                                     }
                                     ]
                                 },

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -35,14 +35,14 @@ def test_compress_pulse_history(pulse_length, num_pulses, exp_tirr):
 
     assert obs_tirr == exp_tirr
 
-@pytest.mark.parametrize( "pulse_length,nums_pulses,dwell_times,exp_tot_tirr,exp_tot_ff",
+@pytest.mark.parametrize( "pulse_length,pulse_history,,exp_tot_tirr,exp_tot_ff",
                           [
-                            (1, [1,1], [1,1], 1, 1),
-                            (1, [2,2], [1,2], 8, 4/8),
-                            (2, [1,2], [2,2], 6, 4/6)
+                            (1, [(1,1), (1,1)], 1, 1),
+                            (1, [(2,1), (2,2)], 8, 4/8),
+                            (2, [(1,2), (2,2)], 6, 4/6)
                           ])
-def test_flatten_ph_levels(pulse_length, nums_pulses, dwell_times, exp_tot_tirr, exp_tot_ff):
-    obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, nums_pulses, dwell_times)
+def test_flatten_ph_levels(pulse_length, pulse_history, exp_tot_tirr, exp_tot_ff):
+    obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, pulse_history)
 
     assert obs_tot_tirr == exp_tot_tirr
     assert obs_tot_ff == exp_tot_ff
@@ -58,126 +58,113 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
     assert obs_tot_tirr == exp_tot_tirr
 
-@pytest.mark.parametrize( "child_dicts, sched_delay_dur, sched_np, sched_ph_dt, exp_tirr, exp_ff",
+@pytest.mark.parametrize( "child_dicts, pulse_history, sched_delay_dur, exp_tirr, exp_ff",
                           [
-                            ({'children':
-                              [{
+                            ([
+                                {
                                 'type': 'schedule',
+                                'pulse_history':[(1,1)],
                                 'sched_delay_dur': 1,
-                                'nums_pulses': [1],
-                                'ph_dwell_times':[1],
                                 'children':
                                     [
                                     {'type': 'pulse_entry',
                                     'pulse_length': 1,
-                                    'pe_delay_dur' : 1,
-                                    'nums_pulses': [1],
-                                    'ph_dwell_times': [1]},
+                                    'pulse_history':[(1,1)],
+                                    'pe_delay_dur' : 1
+                                    },
 
                                     {'type': 'pulse_entry',
                                     'pulse_length': 1,
-                                    'pe_delay_dur' : 1,
-                                    'nums_pulses': [1],
-                                    'ph_dwell_times': [1]}
-                                    ]},
-                               ]
-                               },
+                                    'pulse_history':[(1,1)],
+                                    'pe_delay_dur' : 1
+                                    }
+                                    ]
+                               }
+                            ],
 
+                               [(1,0)],
                                0,
-                               [1],
-                               [0],
                                5,
                                2/5),
 
-                            ({'children':
-                              [
+                            ([
                                 {
                                 'type': 'schedule',
+                                'pulse_history':[(1,1)],
                                 'sched_delay_dur': 5,
-                                'nums_pulses': [1],
-                                'ph_dwell_times':[1],
                                 'children':
                                     [
                                     {'type': 'pulse_entry',
                                     'pulse_length': 10,
-                                    'pe_delay_dur' : 20,
-                                    'nums_pulses': [1],
-                                    'ph_dwell_times': [1]},
+                                    'pulse_history':[(1,1)],
+                                    'pe_delay_dur' : 20
+                                    },
 
                                     {'type': 'pulse_entry',
                                     'pulse_length': 2,
-                                    'pe_delay_dur' : 10,
-                                    'nums_pulses': [1],
-                                    'ph_dwell_times': [1]},
+                                    'pulse_history':[(1,1)],
+                                    'pe_delay_dur' : 10
+                                    },
 
                                     {'type': 'schedule',
+                                    'pulse_history':[(1,1)],
                                     'sched_delay_dur': 2,
-                                    'nums_pulses': [1],
-                                    'ph_dwell_times': [1],
                                     'children':
                                         [
                                         {'type': 'pulse_entry',
                                         'pulse_length': 5,
-                                        'pe_delay_dur' : 10,
-                                        'nums_pulses': [1],
-                                        'ph_dwell_times': [1]
+                                        'pulse_history':[(1,1)],
+                                        'pe_delay_dur' : 10
                                         }
                                         ]
                                     },
                                     {'type': 'schedule',
+                                    'pulse_history':[(1,1)],
                                     'sched_delay_dur': 2,
-                                    'nums_pulses': [1],
-                                    'ph_dwell_times': [1],
                                     'children':
                                         [
                                         {'type': 'pulse_entry',
                                         'pulse_length': 5,
-                                        'pe_delay_dur' : 3,
-                                        'nums_pulses': [1],
-                                        'ph_dwell_times': [1]
+                                        'pulse_history':[(1,1)],
+                                        'pe_delay_dur' : 3
                                         }
                                         ]
                                     }
 
                                     ]
-                                },
-                               ]
-                               },
+                                }
+                               ],
 
+                               [(1,0)],
                                0,
-                               [1],
-                               [0],
                                74,
                                22/74),
 
-                            ({'children':
-                              [{
+                            ([
+                                {
                                 'type': 'schedule',
                                 'sched_delay_dur': 1,
-                                'nums_pulses': [2],
-                                'ph_dwell_times':[0],
+                                'pulse_history': [(2,0)],
                                 'children':
                                     [
                                     {'type': 'pulse_entry',
                                     'pulse_length': 1,
-                                    'pe_delay_dur' : 1,
-                                    'nums_pulses': [2],
-                                    'ph_dwell_times': [0]}
-                                    ]},
-                               ]
-                               },
+                                    'pulse_history': [(2,0)],
+                                    'pe_delay_dur' : 1
+                                    }
+                                    ]
+                                },
+                               ],
 
+                               [(1,0)],
                                0,
-                               [1],
-                               [0],
                                7,
                                4/7),
 
                           ])
-def test_flatten_sub_sched(child_dicts, sched_delay_dur, sched_np, sched_ph_dt,
+def test_flatten_sub_sched(child_dicts, pulse_history, sched_delay_dur,
                            exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, sched_delay_dur,
-                                            sched_np, sched_ph_dt)
+    obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, pulse_history, sched_delay_dur)
 
     assert obs_tirr == exp_tirr
     assert obs_ff == exp_ff

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -58,7 +58,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
     assert obs_tot_tirr == exp_tot_tirr
 
-@pytest.mark.parametrize( "child_dicts, pulse_history, sched_delay_dur, exp_tirr, exp_ff",
+@pytest.mark.parametrize( "child_dicts, pulse_history, exp_tirr, exp_ff",
                           [
                             ([
                                 {
@@ -83,7 +83,6 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                             ],
 
                                [(1,0)],
-                               0,
                                5,
                                2/5),
 
@@ -136,7 +135,6 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                ],
 
                                [(1,0)],
-                               0,
                                74,
                                22/74),
 
@@ -157,14 +155,13 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                ],
 
                                [(1,0)],
-                               0,
                                7,
                                4/7),
 
                           ])
-def test_flatten_sub_sched(child_dicts, pulse_history, sched_delay_dur,
+def test_flatten_sub_sched(child_dicts, pulse_history,
                            exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, pulse_history, sched_delay_dur)
+    obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, pulse_history)
 
     assert obs_tirr == exp_tirr
     assert obs_ff == exp_ff

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -83,8 +83,8 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                             ],
 
                                [(1,0)],
-                               5,
-                               2/5),
+                               3,
+                               2/3),
 
                             ([
                                 {
@@ -135,8 +135,8 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                ],
 
                                [(1,0)],
-                               74,
-                               22/74),
+                               54,
+                               22/54),
 
                             ([
                                 {
@@ -155,13 +155,13 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                ],
 
                                [(1,0)],
-                               7,
-                               4/7),
+                               4,
+                               4/4),
 
                           ])
 def test_flatten_sub_sched(child_dicts, pulse_history,
                            exp_tirr, exp_ff):
     obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, pulse_history)
 
-    assert obs_tirr == exp_tirr
-    assert obs_ff == exp_ff
+    assert obs_tirr == pytest.approx(exp_tirr)
+    assert obs_ff == pytest.approx(exp_ff)

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -1,64 +1,64 @@
 import pytest
 import schedule_transforms as st
 
-@pytest.mark.parametrize( "pulse_length,num_pulses,dwell_time,exp_tirr,exp_ff",
+@pytest.mark.parametrize( "pulse_length,num_pulses,dwell_time,exp_dur,exp_fluence",
                           [
                             (1, 1, 1, 1, 1),
-                            (1, 2, 1, 3, 2/3),
-                            (2, 4, 6, 26, 8/26)
+                            (1, 2, 1, 3, 2),
+                            (2, 4, 6, 26, 8)
                           ])
-def test_single_pulse_history(pulse_length, num_pulses, dwell_time, exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_pulse_history(pulse_length, num_pulses, dwell_time)
+def test_single_pulse_history(pulse_length, num_pulses, dwell_time, exp_dur, exp_fluence):
+    obs_dur, obs_fluence = st.flatten_pulse_history(pulse_length, num_pulses, dwell_time)
 
-    assert obs_tirr == exp_tirr
-    assert obs_ff == exp_ff
+    assert obs_dur == exp_dur
+    assert obs_fluence == exp_fluence
 
-@pytest.mark.parametrize( "pulse_length,num_tot_pulses,dwell_time,num_final_pulses,exp_tirr,exp_ff",
+@pytest.mark.parametrize( "pulse_length,num_tot_pulses,dwell_time,num_final_pulses,exp_dur,exp_fluence",
                           [
-                            (1, 5, 2, 1, 10, 4/10),
-                            (5, 5, 1, 1, 23, 20/23),
-                            (5, 5, 1, 3, 11, 10/11)
+                            (1, 5, 2, 1, 10, 4),
+                            (5, 5, 1, 1, 23, 20),
+                            (5, 5, 1, 3, 11, 10)
                           ])
-def test_flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_final_pulses, exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_final_pulses)
+def test_flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_final_pulses, exp_dur, exp_fluence):
+    obs_dur, obs_fluence = st.flatten_ph_exact_pulses(pulse_length, num_tot_pulses, dwell_time, num_final_pulses)
 
-    assert obs_tirr == exp_tirr
-    assert obs_ff == exp_ff
-@pytest.mark.parametrize( "pulse_length,num_pulses,exp_tirr",
+    assert obs_dur == exp_dur
+    assert obs_fluence == exp_fluence
+@pytest.mark.parametrize( "pulse_length,num_pulses,exp_dur",
                           [
                             (1, 1, 1),
                             (1, 2, 2),
                             (10, 5, 50)
                           ])
-def test_compress_pulse_history(pulse_length, num_pulses, exp_tirr):
-    obs_tirr = st.compress_pulse_history(pulse_length, num_pulses)
+def test_compress_pulse_history(pulse_length, num_pulses, exp_dur):
+    obs_dur = st.compress_pulse_history(pulse_length, num_pulses)
 
-    assert obs_tirr == exp_tirr
+    assert obs_dur == exp_dur
 
-@pytest.mark.parametrize( "pulse_length,pulse_history,,exp_tot_tirr,exp_tot_ff",
+@pytest.mark.parametrize( "pulse_length,pulse_history,exp_tot_dur,exp_tot_fluence",
                           [
                             (1, [(1,1), (1,1)], 1, 1),
-                            (1, [(2,1), (2,2)], 8, 4/8),
-                            (2, [(1,2), (2,2)], 6, 4/6)
+                            (1, [(2,1), (2,2)], 8, 4),
+                            (2, [(1,2), (2,2)], 6, 4)
                           ])
-def test_flatten_ph_levels(pulse_length, pulse_history, exp_tot_tirr, exp_tot_ff):
-    obs_tot_tirr, obs_tot_ff = st.flatten_ph_levels(pulse_length, pulse_history)
+def test_flatten_ph_levels(pulse_length, pulse_history, exp_tot_dur, exp_tot_fluence):
+    obs_tot_dur, obs_tot_fluence = st.flatten_ph_levels(pulse_length, pulse_history)
 
-    assert obs_tot_tirr == exp_tot_tirr
-    assert obs_tot_ff == exp_tot_ff
+    assert obs_tot_dur == exp_tot_dur
+    assert obs_tot_fluence == exp_tot_fluence
 
-@pytest.mark.parametrize( "pulse_length,nums_pulses,exp_tot_tirr",
+@pytest.mark.parametrize( "pulse_length,nums_pulses,exp_tot_dur",
                           [
                             (1, [1,1], 1),
                             (1, [2,2], 4),
                             (2, [5,7], 70)
                           ])
-def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
-    obs_tot_tirr = st.compress_ph_levels(pulse_length, nums_pulses)
+def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_dur):
+    obs_tot_dur = st.compress_ph_levels(pulse_length, nums_pulses)
 
-    assert obs_tot_tirr == exp_tot_tirr
+    assert obs_tot_dur == exp_tot_dur
 
-@pytest.mark.parametrize( "child_dicts, pulse_history, exp_tirr, exp_ff",
+@pytest.mark.parametrize( "child_dicts, pulse_history, exp_dur, exp_fluence",
                           [
                             ([
                                 {
@@ -84,7 +84,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
                                [(1,0)],
                                3,
-                               2/3),
+                               2),
 
                             ([
                                 {
@@ -136,7 +136,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
                                [(1,0)],
                                54,
-                               22/54),
+                               22),
 
                             ([
                                 {
@@ -156,7 +156,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
                                [(1,0)],
                                4,
-                               4/4),
+                               4),
 
                             ([
                                 {
@@ -189,12 +189,12 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
                                [(1,0)],
                                9,
-                               8/9),
+                               8),
 
                           ])
 def test_flatten_schedule(child_dicts, pulse_history,
-                           exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_schedule(child_dicts, pulse_history)
+                           exp_dur, exp_fluence):
+    obs_dur, obs_fluence = st.flatten_schedule(child_dicts, pulse_history)
 
-    assert obs_tirr == pytest.approx(exp_tirr)
-    assert obs_ff == pytest.approx(exp_ff)
+    assert obs_dur == pytest.approx(exp_dur)
+    assert obs_fluence == pytest.approx(exp_fluence)

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -192,9 +192,9 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                8/9),
 
                           ])
-def test_flatten_sub_sched(child_dicts, pulse_history,
+def test_flatten_schedule(child_dicts, pulse_history,
                            exp_tirr, exp_ff):
-    obs_tirr, obs_ff = st.flatten_sub_sched(child_dicts, pulse_history)
+    obs_tirr, obs_ff = st.flatten_schedule(child_dicts, pulse_history)
 
     assert obs_tirr == pytest.approx(exp_tirr)
     assert obs_ff == pytest.approx(exp_ff)

--- a/tools/test_schedule_transforms.py
+++ b/tools/test_schedule_transforms.py
@@ -64,7 +64,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                 {
                                 'type': 'schedule',
                                 'pulse_history':[(1,1)],
-                                'sched_delay_dur': 1,
+                                'delay_dur': 1,
                                 'children':
                                     [
                                     {'type': 'pulse_entry',
@@ -90,7 +90,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                 {
                                 'type': 'schedule',
                                 'pulse_history':[(1,1)],
-                                'sched_delay_dur': 5,
+                                'delay_dur': 5,
                                 'children':
                                     [
                                     {'type': 'pulse_entry',
@@ -107,7 +107,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
 
                                     {'type': 'schedule',
                                     'pulse_history':[(1,1)],
-                                    'sched_delay_dur': 2,
+                                    'delay_dur': 2,
                                     'children':
                                         [
                                         {'type': 'pulse_entry',
@@ -119,7 +119,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                                     },
                                     {'type': 'schedule',
                                     'pulse_history':[(1,1)],
-                                    'sched_delay_dur': 2,
+                                    'delay_dur': 2,
                                     'children':
                                         [
                                         {'type': 'pulse_entry',
@@ -141,7 +141,7 @@ def test_compress_ph_levels(pulse_length, nums_pulses, exp_tot_tirr):
                             ([
                                 {
                                 'type': 'schedule',
-                                'sched_delay_dur': 1,
+                                'delay_dur': 1,
                                 'pulse_history': [(2,0)],
                                 'children':
                                     [


### PR DESCRIPTION
Adds a function to calculate characteristic time for the case where a schedule is used as the sub-schedule. The sub-schedule itself may have an arbitrary number of pulse entries and/or sub-schedules.

Over the course of making this, I've realized that it's a little unclear to me which dwell times ALARA actually ignores when they are applied at the end of the pulsing scheme. While I would like to discuss this in person, it's assumed for now in the function that the user provides dwell time data that is appropriate to how ALARA would interpret and process it.

~~addresses~~ fixes #24 