### PR TITLE
Make and test methods for ITER DT cases

### DIFF
--- a/tools/example_case_reader.py
+++ b/tools/example_case_reader.py
@@ -1,0 +1,57 @@
+import argparse
+import yaml
+import numpy as np
+import alara_output_processing as aop
+import pandas as pd
+import script_template as script_temp
+
+'''
+Runs and tests the methods in script_template.py using a series of run dictionaries
+with various pulse numbers and duty cycles.
+'''
+
+def calc_time_params(active_burn_time, duty_cycle_list, num_pulses):
+    '''
+    Uses provided pulsing information to determine dwell time and total irradiation time.
+    Assumes that the active irradiation time per pulse and dwell time between pulses both remain constant in any given simulation.
+    Iterates over the number of pulses, and for each number, calculates dwell time.
+    The duty cycle is defined as the pulse length / (pulse length + dwell time).
+    inputs:
+        active_burn_time : total active irradiation time (float) in any chosen unit
+        duty_cycle_list : list of chosen duty cycles (float)
+        num_pulses : list of number of pulses (int) that the active irradiation period is divided into
+    '''
+    pulse_lengths = active_burn_time / num_pulses
+    rel_dwell_times = (1 - duty_cycle_list) / duty_cycle_list
+    abs_dwell_times = np.outer(rel_dwell_times, pulse_lengths)
+    t_irr_arr = active_burn_time + abs_dwell_times * (num_pulses - 1)
+    return t_irr_arr
+
+def write_to_adf(run_dicts):
+    adf_data = []
+    for run_dict in run_dicts:
+        lib = aop.DataLibrary()
+        adf = lib.make_entries(run_dicts[run_dict])
+        adf_data.append(adf)
+    adf = pd.concat(adf_data)  
+    return adf
+
+def assign_adf_tirr_arr_mod(adf, t_irr_arr, num_pulses, duty_cycles):
+    '''
+    Maps each of the number of pulses and duty cycle values from the run label to an iterator,
+    from which the corresponding value of the irradiation time is identified. The irradiation
+    time array is added to a new column in the adf by running the map_adf_flux_tirr() method from
+    script_template.py.
+    '''
+    pulse_num_dc = adf["run_lbl"].str.extract(r"_(\d+)p_(\d+)_").astype(int)
+    # Map num_pulses and duty_cycles to an index
+    pulse_idx = pulse_num_dc[0].map(
+        {pulse_num: i
+         for i, pulse_num in enumerate(num_pulses)})
+    duty_cycle_idx = (pulse_num_dc[1] / 100).map(
+        {duty_cycle: i
+         for i, duty_cycle in enumerate(duty_cycles)})
+    t_irr_arr_mod = t_irr_arr.T[pulse_idx.to_numpy(),
+                                duty_cycle_idx.to_numpy()]
+    adf["t_irr"] = t_irr_arr_mod
+    return adf

--- a/tools/iter_dt_out.yaml
+++ b/tools/iter_dt_out.yaml
@@ -11,5 +11,33 @@ num_pulses :
   - 4
   - 8
   - 32
-  - 64  
-flux_file : /filespace/a/asrajendra/research/activationDB/ref_flux_files/iter_dt_flux_2.0986E14
+  - 64
+
+run_dicts :
+    iter_dt_100_4y :
+        iter_dt_2p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_2p_100_4y_out
+        iter_dt_4p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_4p_100_4y_out
+        iter_dt_8p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_8p_100_4y_out
+        iter_dt_32p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_32p_100_4y_out
+        iter_dt_64p_100_4y : ../calc_dwell_dir/iter/duty_cycle_100/output_100/iter_dt_64p_100_4y_out
+
+    iter_dt_90_4y :
+        iter_dt_2p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_2p_90_4y_out
+        iter_dt_4p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_4p_90_4y_out    
+        iter_dt_8p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_8p_90_4y_out
+        iter_dt_32p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_32p_90_4y_out
+        iter_dt_64p_90_4y : ../calc_dwell_dir/iter/duty_cycle_90/output_90/iter_dt_64p_90_4y_out
+
+    iter_dt_50_4y :
+        iter_dt_2p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_2p_50_4y_out
+        iter_dt_4p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_4p_50_4y_out
+        iter_dt_8p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_8p_50_4y_out  
+        iter_dt_32p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_32p_50_4y_out  
+        iter_dt_64p_50_4y : ../calc_dwell_dir/iter/duty_cycle_50/output_50/iter_dt_64p_50_4y_out
+
+    iter_dt_25_4y :
+        iter_dt_2p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_2p_25_4y_out
+        iter_dt_4p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_4p_25_4y_out    
+        iter_dt_8p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_8p_25_4y_out
+        iter_dt_32p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_32p_25_4y_out
+        iter_dt_64p_25_4y : ../calc_dwell_dir/iter/duty_cycle_25/output_25/iter_dt_64p_25_4y_out

--- a/tools/test_example_case_reader.py
+++ b/tools/test_example_case_reader.py
@@ -1,0 +1,69 @@
+import argparse
+import yaml
+import numpy as np
+import example_case_reader as ecr
+
+'''
+Runs and tests the methods in script_template.py using a series of run dictionaries
+with various pulse numbers and duty cycles.
+'''
+def test_write_to_adf(adf, run_dicts):
+    '''
+    Ensure that entries from all cases have been written into the adf.
+    '''
+    assert len(adf['run_lbl'].unique()) == sum([len(run_lbl) for _, run_lbl in run_dicts.items()])
+
+def test_assign_adf_tirr_arr_mod(adf):
+    '''
+    Ensure that two of the run labels are associated with the correct irradiation time.
+    '''
+    assert not ((adf["run_lbl"] == "iter_dt_2p_100_4y")
+                & (adf["t_irr"] != 4)).any()
+    assert not ((adf["run_lbl"] == "iter_dt_64p_25_4y")
+                & (adf["t_irr"] != 15.8125)).any()
+    
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--db_yaml",
+        default="iter_dt_out.yaml",
+        help="Path (str) to YAML containing inputs",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def read_yaml(yaml_arg):
+    """
+    input:
+        yaml_arg : output of parse_args() corresponding to args.db_yaml
+    """
+    with open(yaml_arg, "r") as yaml_file:
+        inputs = yaml.safe_load(yaml_file)
+    return inputs
+
+
+def main():
+    args = parse_args()
+    inputs = read_yaml(args.db_yaml)
+
+    active_burn_time = np.asarray(inputs["active_burn_time"])
+    duty_cycle_list = np.asarray(inputs["duty_cycles"])
+    num_pulses = np.asarray(inputs["num_pulses"])
+    t_irr_arr = ecr.calc_time_params(active_burn_time, duty_cycle_list,
+                                             num_pulses)
+
+    run_dicts = inputs["run_dicts"]
+    adf = ecr.write_to_adf(run_dicts)
+    test_write_to_adf(adf, run_dicts)
+
+    num_pulses = inputs["num_pulses"]
+    duty_cycles = inputs["duty_cycles"]
+
+    adf = ecr.assign_adf_tirr_arr_mod(adf, t_irr_arr, num_pulses,
+                            duty_cycles)
+    test_assign_adf_tirr_arr_mod(adf)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`example_case_reader.py` makes methods that are designed to function specifically with the data structure of the test cases given in the YAML. These methods take advantage of the test cases being grouped by pulse numbers, duty cycles, and these values being found in the run label.

`test_example_case_reader.py` runs the methods in the main script using a YAML file that contains the names and paths to the test cases. There are two testing functions written to check that the main script functions as expected.

The YAML file was deleted in #75 and added here with information needed to run the scripts. Notably, the flux file and number of energy bins no longer exist in the YAML as there are currently no tests that require this information. Nevertheless, the ability to parse and extract information from flux files still exists in `script_template.py`.