### PR TITLE
Create training data structure using variations of flux magnitude and fluence

### DIFF
--- a/tools/build_inp_blocks.py
+++ b/tools/build_inp_blocks.py
@@ -17,6 +17,7 @@ as its parent.
     'pulse_length': (float),
     'pulse_length_unit': (str),
     'flux_filepath' : (str),
+    'flux_norm' : (float),
     'pulse_history': (iterable of (int, float, str)),
     'delay_dur' : (float),
     'delay_dur_unit': (str)
@@ -54,7 +55,7 @@ def make_flux_dict(child_dicts, flux_counter=None):
     for child_dict in child_dicts:
         if child_dict['type'] == 'pulse_entry':
             flux_dict[
-                child_dict['flux_filepath']] = f'flux_{next(flux_counter)}'
+                (child_dict['flux_filepath'], child_dict['flux_norm'])] = f'flux_{next(flux_counter)}'
         elif child_dict['type'] == 'schedule':
             flux_dict |= make_flux_dict(child_dict['children'], flux_counter)
 
@@ -66,8 +67,8 @@ def make_flux_block(flux_dict):
     Create the flux block of an ALARA input file.
     '''
     flux_lines = ""
-    for flux_path, name in flux_dict.items():
-        flux_lines += f"flux {name} {flux_path} 0 default\n"
+    for (flux_path, flux_norm), flux_name in flux_dict.items():
+        flux_lines += f"flux {flux_name} {flux_path} {flux_norm} 0 default\n"
     return flux_lines + "\n"
 
 
@@ -99,7 +100,7 @@ def make_schedule_block(child_dicts, ph_dict, flux_dict, sched_counter=None, sch
             current_sched_lines += (
                 f"{child_dict['pulse_length']}\t"
                 f"{child_dict['pulse_length_unit']}\t"
-                f"{flux_dict[child_dict['flux_filepath']]}\t"
+                f"{flux_dict[(child_dict['flux_filepath'], child_dict['flux_norm'])]}\t"
                 f"{ph_dict[tuple(child_dict['pulse_history'])]}\t"
                 f"{child_dict['delay_dur']}\t"
                 f"{child_dict['delay_dur_unit']}\n"
@@ -149,7 +150,7 @@ def make_volume_block(nuclib_lines, volume):
 
 
 def make_input_lines(vol_lines, load_lines, mix_lines, flux_lines, all_ph_lines, all_sched_lines,
-                     trunc_tolerance, nuclib_lines):
+                     trunc_tolerance):
     """
     Collect volume, loading, and mixture blocks from make_volume_block().
     Assemble with data and output block-related lines that are expected to change infrequently.

--- a/tools/test_build_inp_blocks.py
+++ b/tools/test_build_inp_blocks.py
@@ -16,6 +16,7 @@ def normalize_lines(lines):
                 'pulse_length': 7.6,
                 'pulse_length_unit': 'm',
                 'flux_filepath': './ex_flux',
+                'flux_norm' : 0.5,
                 'pulse_history': [(3, 7.9, 'm'), (2, 5.5, 's'), (9, 1.2, 'c')],
                 'delay_dur': 5.1,
                 'delay_dur_unit': 's'
@@ -24,6 +25,7 @@ def normalize_lines(lines):
                 'pulse_length': 7.6,
                 'pulse_length_unit': 's',
                 'flux_filepath': '../flux_file',
+                'flux_norm' : 0.9,
                 'pulse_history': [(1, 8.0, 'm'), (2, 3, 's'), (9, 1.1, 'c')],
                 'delay_dur': 5.8,
                 'delay_dur_unit': 'm'
@@ -37,6 +39,7 @@ def normalize_lines(lines):
         'pulse_length': 7.4,
         'pulse_length_unit': 'd',
         'flux_filepath': './iter_flux',
+        'flux_norm' : 1,
         'pulse_history': [(3, 7.9, 'm'), (2, 5.5, 's'), (9, 1.2, 'c')],
         'delay_dur': 5.33,
         'delay_dur_unit': 'c'
@@ -62,6 +65,7 @@ def test_make_ph_dict(child_dicts, ph_counter, exp_ph_dict):
                 'pulse_length': 7.6,
                 'pulse_length_unit': 'm',
                 'flux_filepath': './ex_flux',
+                'flux_norm' : 0.7,
                 'pulse_history': [(3, 7.9, 'm'), (2, 5.5, 's'), (9, 1.2, 'c')],
                 'delay_dur': 5.1,
                 'delay_dur_unit': 's'
@@ -70,6 +74,7 @@ def test_make_ph_dict(child_dicts, ph_counter, exp_ph_dict):
                 'pulse_length': 7.6,
                 'pulse_length_unit': 's',
                 'flux_filepath': '../flux_file',
+                'flux_norm' : 1,
                 'pulse_history': [(1, 8.0, 'm'), (2, 3, 's'), (9, 1.1, 'c')],
                 'delay_dur': 5.8,
                 'delay_dur_unit': 'm'
@@ -83,14 +88,16 @@ def test_make_ph_dict(child_dicts, ph_counter, exp_ph_dict):
         'pulse_length': 7.4,
         'pulse_length_unit': 'd',
         'flux_filepath': '../flux_file',
+        'flux_norm' : 0.6,
         'pulse_history': [(3, 7.9, 'm'), (2, 5.5, 's'), (9, 1.2, 'c')],
         'delay_dur': 5.33,
         'delay_dur_unit': 'c'
     }],
     None,
     {
-        './ex_flux' : 'flux_1',
-        '../flux_file' : 'flux_3'
+        ('./ex_flux', 0.7) : 'flux_1',
+        ('../flux_file', 1) : 'flux_2',
+        ('../flux_file', 0.6) : 'flux_3'
     })
     ])
 
@@ -100,12 +107,12 @@ def test_make_flux_dict(child_dicts, flux_counter, exp_flux_dict):
 
 @pytest.mark.parametrize("flux_dict, exp_flux_block", [
     ({
-        './ex_flux' : 'flux_1',
-        '../flux_file' : 'flux_3'
+        ('./ex_flux', 1) : 'flux_1',
+        ('../flux_file', 2) : 'flux_3'
     },
     """
-    flux flux_1 ./ex_flux 0 default
-    flux flux_3 ../flux_file 0 default
+    flux flux_1 ./ex_flux 1 0 default
+    flux flux_3 ../flux_file 2 0 default
     """
     )
     ])
@@ -149,6 +156,7 @@ def test_make_pulse_history_block(ph_dict, exp_ph_block):
                 'pulse_length': 7.6,
                 'pulse_length_unit': 'm',
                 'flux_filepath': './iter_flux_2',
+                'flux_norm' : 0.2,
                 'pulse_history': [(3, 7.9, 'm'), (2, 5.5, 's'), (9, 1.2, 'c')],
                 'delay_dur': 5.1,
                 'delay_dur_unit': 's'
@@ -157,6 +165,7 @@ def test_make_pulse_history_block(ph_dict, exp_ph_block):
                 'pulse_length': 7.6,
                 'pulse_length_unit': 's',
                 'flux_filepath': '../frascati_flux_1',
+                'flux_norm' : 5,
                 'pulse_history': [(1, 8.0, 'm'), (2, 3, 's'), (9, 1.1, 'c')],
                 'delay_dur': 5.8,
                 'delay_dur_unit': 'm'
@@ -170,6 +179,7 @@ def test_make_pulse_history_block(ph_dict, exp_ph_block):
         'pulse_length': 7.4,
         'pulse_length_unit': 'd',
         'flux_filepath': '../frascati_flux_1',
+        'flux_norm' : 5,
         'pulse_history': [(3, 7.9, 'm'), (2, 5.5, 's'), (9, 1.2, 'c')],
         'delay_dur': 5.33,
         'delay_dur_unit': 'c'
@@ -180,8 +190,8 @@ def test_make_pulse_history_block(ph_dict, exp_ph_block):
         ((1, 8.0, 'm'), (2, 3, 's'), (9, 1.1, 'c')): 'pulse_history_3'
     },
     {
-        './iter_flux_2' : 'flux_1',
-        '../frascati_flux_1' : 'flux_3'
+        ('./iter_flux_2', 0.2) : 'flux_1',
+        ('../frascati_flux_1', 5) : 'flux_3'
     },
     None,
     "top",
@@ -204,8 +214,8 @@ def test_make_schedule_block(child_dicts, ph_dict, flux_dict, sched_counter,
 
 @pytest.mark.parametrize("flux_lines, all_ph_lines, all_sched_lines, trunc_tolerance, nuclib_lines, exp_assembled_lines", [
     ("""
-    flux flux_1 ./ex_flux 0 default
-    flux flux_3 ../flux_file 0 default
+    flux flux_1 ./ex_flux 3 0 default
+    flux flux_3 ../flux_file 0.3 0 default
     """,
     """pulsehistory  pulse_history_1
         7	9.5	d
@@ -265,8 +275,8 @@ def test_make_schedule_block(child_dicts, ph_dict, flux_dict, sched_counter,
         specific_activity
         number_density
     end
-    flux flux_1 ./ex_flux 0 default
-    flux flux_3 ../flux_file 0 default
+    flux flux_1 ./ex_flux 3 0 default
+    flux flux_3 ../flux_file 0.3 0 default
     schedule top
         sched_1 pulse_history_1	6.3	m
         7.4	d	flux_3	pulse_history_2	5.33	c
@@ -299,7 +309,6 @@ def test_make_input_lines(flux_lines, all_ph_lines, all_sched_lines,
                           trunc_tolerance, nuclib_lines, exp_assembled_lines):
     vol_lines, load_lines, mix_lines = build_inp_blocks.make_volume_block(nuclib_lines, volume=1)
     obs_assembled_lines = build_inp_blocks.make_input_lines(
-        vol_lines, load_lines, mix_lines, flux_lines, all_ph_lines, all_sched_lines, trunc_tolerance,
-        nuclib_lines)
+        vol_lines, load_lines, mix_lines, flux_lines, all_ph_lines, all_sched_lines, trunc_tolerance)
     assert normalize_lines(obs_assembled_lines) == normalize_lines(
         exp_assembled_lines)

--- a/tools/test_training_inp_params_to_dict.py
+++ b/tools/test_training_inp_params_to_dict.py
@@ -2,36 +2,22 @@ import pytest
 import training_inp_params_to_dict
 import numpy as np
 
-@pytest.mark.parametrize("on_times, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts", [
-    (np.array([1, 40]),
+@pytest.mark.parametrize("min_on_time, rel_on_time_factors, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts", [
+    (1,
+    np.array([2, 4]),
      np.array([1, 0.3]),
      np.array(['../iter_flux', '../frascati_flux']),
      'y',
     np.array([
         [
             [
-                {'type': 'pulse_entry',
-      'pulse_length' : 1,
-      'pulse_length_unit': 'y',
-      'flux_filepath' : '../iter_flux',
-      'flux_norm' : 1,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'},
-
-      {'type': 'pulse_entry',
-      'pulse_length' : 1,
-      'pulse_length_unit': 'y',
-      'flux_filepath' : '../frascati_flux',
-      'flux_norm' : 1,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'}
+            None,
+            None
             ],
 
             [
-          {'type': 'pulse_entry',
-      'pulse_length' : 1,
+            {'type': 'pulse_entry',
+      'pulse_length' : 2,
       'pulse_length_unit': 'y',
       'flux_filepath' : '../iter_flux',
       'flux_norm' : 0.3,
@@ -40,7 +26,7 @@ import numpy as np
       'delay_dur_unit' : 's'},
       
       {'type': 'pulse_entry',
-      'pulse_length' : 1,
+      'pulse_length' : 2,
       'pulse_length_unit': 'y',
       'flux_filepath' : '../frascati_flux',
       'flux_norm' : 0.3,
@@ -52,49 +38,19 @@ import numpy as np
 
         [
             [
-                {'type': 'pulse_entry',
-      'pulse_length' : 40,
-      'pulse_length_unit': 'y',
-      'flux_filepath' : '../iter_flux',
-      'flux_norm' : 1,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'},
-
-      {'type': 'pulse_entry',
-      'pulse_length' : 40,
-      'pulse_length_unit': 'y',
-      'flux_filepath' : '../frascati_flux',
-      'flux_norm' : 1,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'}
+            None,
+            None
             ],
 
             [
-                 {'type': 'pulse_entry',
-      'pulse_length' : 40,
-      'pulse_length_unit': 'y',
-      'flux_filepath' : '../iter_flux',
-      'flux_norm' : 0.3,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'},
-
-      {'type': 'pulse_entry',
-      'pulse_length' : 40,
-      'pulse_length_unit': 'y',
-      'flux_filepath' : '../frascati_flux',
-      'flux_norm' : 0.3,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'}
+            None,
+            None
             ]
         ]
       ])
      )
      ])
 
-def test_write_training_params_dict(on_times, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts):
-    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(on_times, flux_norm_factors, flux_files, time_unit)
+def test_write_training_params_dict(min_on_time, rel_on_time_factors, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts):
+    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(min_on_time, rel_on_time_factors, flux_norm_factors, flux_files, time_unit)
     assert np.array_equal(obs_training_child_dicts, exp_training_child_dicts)

--- a/tools/test_training_inp_params_to_dict.py
+++ b/tools/test_training_inp_params_to_dict.py
@@ -1,0 +1,100 @@
+import pytest
+import training_inp_params_to_dict
+import numpy as np
+
+@pytest.mark.parametrize("on_times, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts", [
+    (np.array([1, 40]),
+     np.array([1, 0.3]),
+     np.array(['../iter_flux', '../frascati_flux']),
+     'y',
+    np.array([
+        [
+            [
+                {'type': 'pulse_entry',
+      'pulse_length' : 1,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../iter_flux',
+      'flux_norm' : 1,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'},
+
+      {'type': 'pulse_entry',
+      'pulse_length' : 1,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../frascati_flux',
+      'flux_norm' : 1,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+            ],
+
+            [
+          {'type': 'pulse_entry',
+      'pulse_length' : 1,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../iter_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'},
+      
+      {'type': 'pulse_entry',
+      'pulse_length' : 1,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../frascati_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+            ]
+        ],
+
+        [
+            [
+                {'type': 'pulse_entry',
+      'pulse_length' : 40,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../iter_flux',
+      'flux_norm' : 1,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'},
+
+      {'type': 'pulse_entry',
+      'pulse_length' : 40,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../frascati_flux',
+      'flux_norm' : 1,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+            ],
+
+            [
+                 {'type': 'pulse_entry',
+      'pulse_length' : 40,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../iter_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'},
+
+      {'type': 'pulse_entry',
+      'pulse_length' : 40,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../frascati_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+            ]
+        ]
+      ])
+     )
+     ])
+
+def test_write_training_params_dict(on_times, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts):
+    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(on_times, flux_norm_factors, flux_files, time_unit)
+    assert np.array_equal(obs_training_child_dicts, exp_training_child_dicts)

--- a/tools/test_training_inp_params_to_dict.py
+++ b/tools/test_training_inp_params_to_dict.py
@@ -21,7 +21,7 @@ import numpy as np
       'pulse_length_unit': 'y',
       'flux_filepath' : '../iter_flux',
       'flux_norm' : 0.3,
-      'pulse_history': [1, 0, 's'],
+      'pulse_history': [(1, 0, 's')],
       'delay_dur' : 0.0,
       'delay_dur_unit' : 's'},
       
@@ -30,7 +30,7 @@ import numpy as np
       'pulse_length_unit': 'y',
       'flux_filepath' : '../frascati_flux',
       'flux_norm' : 0.3,
-      'pulse_history': [1, 0, 's'],
+      'pulse_history': [(1, 0, 's')],
       'delay_dur' : 0.0,
       'delay_dur_unit' : 's'}
             ]

--- a/tools/test_training_inp_params_to_dict.py
+++ b/tools/test_training_inp_params_to_dict.py
@@ -2,12 +2,75 @@ import pytest
 import training_inp_params_to_dict
 import numpy as np
 
-@pytest.mark.parametrize("min_on_time, rel_on_time_factors, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts", [
-    (1,
+
+@pytest.mark.parametrize("rel_on_time_factors, flux_norm_factors, flux_files, exp_training_inp_info", [
+    (
     np.array([2, 4]),
-     np.array([1, 0.3]),
-     np.array(['../iter_flux', '../frascati_flux']),
-     'y',
+    np.array([1, 0.3]),
+    np.array(['../iter_flux', '../frascati_flux']),
+    np.array([
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            (2, 0.3, '../iter_flux'),
+      
+      (2, 0.3, '../frascati_flux')
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+      ], dtype=object)
+     )
+     ])
+
+def test_make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_files, exp_training_inp_info):
+    obs_training_inp_info = training_inp_params_to_dict.make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_files)
+    assert np.array_equal(obs_training_inp_info, exp_training_inp_info)
+
+@pytest.mark.parametrize("training_inp_info, min_on_time, time_unit, exp_training_child_dicts", [
+    (
+    np.array([
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            (2, 0.3, '../iter_flux'),
+      
+      (2, 0.3, '../frascati_flux')
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+      ], dtype=object),
+    1,
+    'y',
     np.array([
         [
             [
@@ -51,6 +114,7 @@ import numpy as np
      )
      ])
 
-def test_write_training_params_dict(min_on_time, rel_on_time_factors, flux_norm_factors, flux_files, time_unit, exp_training_child_dicts):
-    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(min_on_time, rel_on_time_factors, flux_norm_factors, flux_files, time_unit)
+
+def test_write_training_params_dict(training_inp_info, min_on_time, time_unit, exp_training_child_dicts):
+    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(training_inp_info, min_on_time, time_unit)
     assert np.array_equal(obs_training_child_dicts, exp_training_child_dicts)

--- a/tools/test_training_inp_params_to_dict.py
+++ b/tools/test_training_inp_params_to_dict.py
@@ -41,7 +41,7 @@ def test_make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_file
     obs_training_inp_info = training_inp_params_to_dict.make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_files)
     assert np.array_equal(obs_training_inp_info, exp_training_inp_info)
 
-@pytest.mark.parametrize("training_inp_info, min_on_time, time_unit, exp_training_child_dicts", [
+@pytest.mark.parametrize("training_inp_info, min_on_times, time_unit, exp_training_child_dicts", [
     (
     np.array([
         [
@@ -69,9 +69,10 @@ def test_make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_file
             ]
         ]
       ], dtype=object),
-    1,
+    [1, 2],
     'y',
     np.array([
+        [
         [
             [
             None,
@@ -110,11 +111,52 @@ def test_make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_file
             None
             ]
         ]
-      ])
+      ],
+      [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            {'type': 'pulse_entry',
+      'pulse_length' : 4,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../iter_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [(1, 0, 's')],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'},
+      
+      {'type': 'pulse_entry',
+      'pulse_length' : 4,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../frascati_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [(1, 0, 's')],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+      ]
+    ])
      )
      ])
 
 
-def test_write_training_params_dict(training_inp_info, min_on_time, time_unit, exp_training_child_dicts):
-    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(training_inp_info, min_on_time, time_unit)
+def test_write_training_params_dict(training_inp_info, min_on_times, time_unit, exp_training_child_dicts):
+    obs_training_child_dicts = training_inp_params_to_dict.write_training_params_dict(training_inp_info, min_on_times, time_unit)
     assert np.array_equal(obs_training_child_dicts, exp_training_child_dicts)

--- a/tools/training_inp_params_to_dict.py
+++ b/tools/training_inp_params_to_dict.py
@@ -1,0 +1,38 @@
+import numpy as np
+from itertools import product
+
+def write_training_params_dict(on_times, flux_norm_factors, flux_files, time_unit):
+  """
+  This function takes a series of input parameters and converts them into a dictionary of the form below.
+  This dictionary can be used to build a single-line schedule with a single-line pulse history.
+  [
+  {'type': 'pulse_entry',
+      'pulse_length': (float),
+      'pulse_length_unit': (str),
+      'flux_filepath' : (str),
+      'flux_norm' : (float),
+      'pulse_history': (iterable of (int, float, str)),
+      'delay_dur' : (float),
+      'delay_dur_unit': (str)
+  }
+  ]
+  :param: on_times (iterable of times (float) during which the flux is nonzero)
+  :param: flux_norm_factors (iterable of factors (float) that scale the maximum flux magnitude)
+  :param: flux_files (iterable of paths (str) to flux files)
+  :param: time_unit (unit (str) of pulse length) 
+  """
+  training_child_dicts = np.ndarray((len(on_times), len(flux_norm_factors), len(flux_files)), dtype=object)
+  for (on_time_idx, on_time), (flux_norm_factor_idx, flux_norm_factor), (flux_file_idx, flux_file) in product(
+      enumerate(on_times), 
+      enumerate(flux_norm_factors), 
+      enumerate(flux_files)
+      ):
+      training_child_dicts[on_time_idx, flux_norm_factor_idx, flux_file_idx] = {'type': 'pulse_entry',
+      'pulse_length' : on_time,
+      'pulse_length_unit': time_unit,
+      'flux_filepath' : flux_file,
+      'flux_norm' : flux_norm_factor,
+      'pulse_history': [1, 0, 's'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+  return training_child_dicts    

--- a/tools/training_inp_params_to_dict.py
+++ b/tools/training_inp_params_to_dict.py
@@ -45,7 +45,7 @@ def write_training_params_dict(min_on_time, rel_on_time_factors,
                                         'pulse_length_unit': time_unit,
                                         'flux_filepath': flux_file,
                                         'flux_norm': flux_norm_factor,
-                                        'pulse_history': [1, 0, 's'],
+                                        'pulse_history': [(1, 0, 's')],
                                         'delay_dur': 0.0,
                                         'delay_dur_unit': 's'}
     return training_child_dicts

--- a/tools/training_inp_params_to_dict.py
+++ b/tools/training_inp_params_to_dict.py
@@ -2,50 +2,57 @@ import numpy as np
 from itertools import product
 
 
-def write_training_params_dict(min_on_time, rel_on_time_factors,
-                               flux_norm_factors, flux_files, time_unit):
+def make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_files):
     """
-    This function takes a series of input parameters and converts them into a dictionary of the form below.
-    This dictionary can be used to build a single-line schedule with a single-line pulse history. A separate
-    dictionary for each viable combination of input parameters is constructed, and each dictionary is stored
-    in a numpy array of shape len(rel_on_time_factors) x len(flux_norm_factors) x len(flux_files).
+    This function calculates combinations of irradiation time and flux normalization factors
+    that do not exceed a prescribed value. The process is repeated for each flux spectrum.
+    The data is stored in a numpy array of shape len(rel_on_time_factors) x len(flux_norm_factors) x len(flux_files).
 
     The total amount of fluence is defined by the product of the minimum on-time
     and the maximum flux magnitude. If a combination of on-time and flux scaling factors results in
-    the total fluence being exceeded, the corresponding entry in the numpy array of dictionaries is
+    the total fluence being exceeded, the corresponding entry in the numpy array of input information is
     set to None.
-    [
-    {'type': 'pulse_entry',
-        'pulse_length': (float),
-        'pulse_length_unit': (str),
-        'flux_filepath' : (str),
-        'flux_norm' : (float),
-        'pulse_history': (iterable of (int, float, str)),
-        'delay_dur' : (float),
-        'delay_dur_unit': (str)
-    }
-    ]
-    :param: min_on_time (minimum total amount of time (float) during which the flux is nonzero)
+
     :param: rel_on_time_factors (iterable of factors (float) that scale the minimum on-time)
     :param: flux_norm_factors (iterable of factors (float) that scale the maximum flux magnitude)
     :param: flux_files (iterable of paths (str) to flux files)
-    :param: time_unit (unit (str) of pulse length)
     """
-    training_child_dicts = np.ndarray((len(rel_on_time_factors), len(flux_norm_factors), len(flux_files)), dtype=object)
+    training_inp_info = np.ndarray((len(rel_on_time_factors), len(flux_norm_factors), len(flux_files)), dtype=object)
     for (rel_on_time_factor_idx, rel_on_time_factor), (flux_norm_factor_idx, flux_norm_factor), (flux_file_idx, flux_file) in product(
                 enumerate(rel_on_time_factors),
                 enumerate(flux_norm_factors),
                 enumerate(flux_files)):
         if rel_on_time_factor * flux_norm_factor > 1:
-            training_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
+            training_inp_info[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
         else:
-            training_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = {
-                                        'type': 'pulse_entry',
-                                        'pulse_length': min_on_time * rel_on_time_factor,
-                                        'pulse_length_unit': time_unit,
-                                        'flux_filepath': flux_file,
-                                        'flux_norm': flux_norm_factor,
-                                        'pulse_history': [(1, 0, 's')],
-                                        'delay_dur': 0.0,
-                                        'delay_dur_unit': 's'}
-    return training_child_dicts
+            training_inp_info[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = (rel_on_time_factor, flux_norm_factor, flux_file)
+    return training_inp_info
+
+
+def write_training_params_dict(training_inp_info, min_on_time, time_unit):
+    """
+    This function takes a an array of input parameters and converts them into a dictionary of the form below.
+    This dictionary can be used to build a single-line schedule with a single-line pulse history. A separate
+    dictionary for each viable combination of input parameters is constructed, and each dictionary is stored
+    in a numpy array of shape len(rel_on_time_factors) x len(flux_norm_factors) x len(flux_files).
+
+    :param: min_on_time (minimum total amount of time (float) during which the flux is nonzero)
+    :param: time_unit (unit (str) of pulse length)
+    """
+    training_child_dicts = np.empty_like(training_inp_info)
+    for inp_info_idx in np.ndindex(training_inp_info.shape):
+        if training_inp_info[inp_info_idx] == None:
+            continue
+        else:
+            rel_on_time_factor, flux_norm_factor, flux_file = training_inp_info[inp_info_idx]
+            training_child_dicts[inp_info_idx] = {
+                        'type': 'pulse_entry',
+                        'pulse_length': min_on_time * rel_on_time_factor,
+                        'pulse_length_unit': time_unit,
+                        'flux_filepath': flux_file,
+                        'flux_norm': flux_norm_factor,
+                        'pulse_history': [(1, 0, 's')],
+                        'delay_dur': 0.0,
+                        'delay_dur_unit': 's'
+                        }
+    return training_child_dicts    

--- a/tools/training_inp_params_to_dict.py
+++ b/tools/training_inp_params_to_dict.py
@@ -1,38 +1,51 @@
 import numpy as np
 from itertools import product
 
-def write_training_params_dict(on_times, flux_norm_factors, flux_files, time_unit):
-  """
-  This function takes a series of input parameters and converts them into a dictionary of the form below.
-  This dictionary can be used to build a single-line schedule with a single-line pulse history.
-  [
-  {'type': 'pulse_entry',
-      'pulse_length': (float),
-      'pulse_length_unit': (str),
-      'flux_filepath' : (str),
-      'flux_norm' : (float),
-      'pulse_history': (iterable of (int, float, str)),
-      'delay_dur' : (float),
-      'delay_dur_unit': (str)
-  }
-  ]
-  :param: on_times (iterable of times (float) during which the flux is nonzero)
-  :param: flux_norm_factors (iterable of factors (float) that scale the maximum flux magnitude)
-  :param: flux_files (iterable of paths (str) to flux files)
-  :param: time_unit (unit (str) of pulse length) 
-  """
-  training_child_dicts = np.ndarray((len(on_times), len(flux_norm_factors), len(flux_files)), dtype=object)
-  for (on_time_idx, on_time), (flux_norm_factor_idx, flux_norm_factor), (flux_file_idx, flux_file) in product(
-      enumerate(on_times), 
-      enumerate(flux_norm_factors), 
-      enumerate(flux_files)
-      ):
-      training_child_dicts[on_time_idx, flux_norm_factor_idx, flux_file_idx] = {'type': 'pulse_entry',
-      'pulse_length' : on_time,
-      'pulse_length_unit': time_unit,
-      'flux_filepath' : flux_file,
-      'flux_norm' : flux_norm_factor,
-      'pulse_history': [1, 0, 's'],
-      'delay_dur' : 0.0,
-      'delay_dur_unit' : 's'}
-  return training_child_dicts    
+
+def write_training_params_dict(min_on_time, rel_on_time_factors,
+                               flux_norm_factors, flux_files, time_unit):
+    """
+    This function takes a series of input parameters and converts them into a dictionary of the form below.
+    This dictionary can be used to build a single-line schedule with a single-line pulse history. A separate
+    dictionary for each viable combination of input parameters is constructed, and each dictionary is stored
+    in a numpy array of shape len(rel_on_time_factors) x len(flux_norm_factors) x len(flux_files).
+
+    The total amount of fluence is defined by the product of the minimum on-time
+    and the maximum flux magnitude. If a combination of on-time and flux scaling factors results in
+    the total fluence being exceeded, the corresponding entry in the numpy array of dictionaries is
+    set to None.
+    [
+    {'type': 'pulse_entry',
+        'pulse_length': (float),
+        'pulse_length_unit': (str),
+        'flux_filepath' : (str),
+        'flux_norm' : (float),
+        'pulse_history': (iterable of (int, float, str)),
+        'delay_dur' : (float),
+        'delay_dur_unit': (str)
+    }
+    ]
+    :param: min_on_time (minimum total amount of time (float) during which the flux is nonzero)
+    :param: rel_on_time_factors (iterable of factors (float) that scale the minimum on-time)
+    :param: flux_norm_factors (iterable of factors (float) that scale the maximum flux magnitude)
+    :param: flux_files (iterable of paths (str) to flux files)
+    :param: time_unit (unit (str) of pulse length)
+    """
+    training_child_dicts = np.ndarray((len(rel_on_time_factors), len(flux_norm_factors), len(flux_files)), dtype=object)
+    for (rel_on_time_factor_idx, rel_on_time_factor), (flux_norm_factor_idx, flux_norm_factor), (flux_file_idx, flux_file) in product(
+                enumerate(rel_on_time_factors),
+                enumerate(flux_norm_factors),
+                enumerate(flux_files)):
+        if rel_on_time_factor * flux_norm_factor > 1:
+            training_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
+        else:
+            training_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = {
+                                        'type': 'pulse_entry',
+                                        'pulse_length': min_on_time * rel_on_time_factor,
+                                        'pulse_length_unit': time_unit,
+                                        'flux_filepath': flux_file,
+                                        'flux_norm': flux_norm_factor,
+                                        'pulse_history': [1, 0, 's'],
+                                        'delay_dur': 0.0,
+                                        'delay_dur_unit': 's'}
+    return training_child_dicts

--- a/tools/training_inp_params_to_dict.py
+++ b/tools/training_inp_params_to_dict.py
@@ -29,25 +29,25 @@ def make_flux_tirr_combos(rel_on_time_factors, flux_norm_factors, flux_files):
     return training_inp_info
 
 
-def write_training_params_dict(training_inp_info, min_on_time, time_unit):
+def write_training_params_dict(training_inp_info, min_on_times, time_unit):
     """
     This function takes a an array of input parameters and converts them into a dictionary of the form below.
     This dictionary can be used to build a single-line schedule with a single-line pulse history. A separate
     dictionary for each viable combination of input parameters is constructed, and each dictionary is stored
     in a numpy array of shape len(rel_on_time_factors) x len(flux_norm_factors) x len(flux_files).
 
-    :param: min_on_time (minimum total amount of time (float) during which the flux is nonzero)
+    :param: min_on_times (iterable of minimum total amount of time (float) during which the flux is nonzero)
     :param: time_unit (unit (str) of pulse length)
     """
-    training_child_dicts = np.empty_like(training_inp_info)
-    for inp_info_idx in np.ndindex(training_inp_info.shape):
-        if training_inp_info[inp_info_idx] == None:
+    training_child_dicts = np.empty((len(min_on_times),) + training_inp_info.shape, dtype=object)
+    for (min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx), _ in np.ndenumerate(training_child_dicts):
+        if training_inp_info[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] == None:
             continue
         else:
-            rel_on_time_factor, flux_norm_factor, flux_file = training_inp_info[inp_info_idx]
-            training_child_dicts[inp_info_idx] = {
+            rel_on_time_factor, flux_norm_factor, flux_file = training_inp_info[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx]
+            training_child_dicts[min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = {
                         'type': 'pulse_entry',
-                        'pulse_length': min_on_time * rel_on_time_factor,
+                        'pulse_length': min_on_times[min_on_time_idx] * rel_on_time_factor,
                         'pulse_length_unit': time_unit,
                         'flux_filepath': flux_file,
                         'flux_norm': flux_norm_factor,


### PR DESCRIPTION
Following our discussing earlier today, I've set up a way to create a dictionary based on the parameters required for an initial training dataset. This dictionary makes a single pulse entry with a history consisting of a single pulse.

`build_inp_blocks.py` has been modified to allow for variations in flux magnitude using a scalar normalization factor, which was previously assumed to be 1. This required a slight change to the structure of `flux_dict` in the script.

addresses #37
fixes #92 