### PR TITLE
Populate child dictionary for simple testing cases

### DIFF
--- a/tools/test_testing_case_inp_params_to_dict.py
+++ b/tools/test_testing_case_inp_params_to_dict.py
@@ -1,0 +1,183 @@
+import numpy as np
+import pytest
+import testing_case_inp_params_to_dict as tcipd
+
+@pytest.mark.parametrize("fluences, duty_cycles, nums_pulses, exp_pulse_lengths, exp_abs_dwell_times", [
+                            (np.array([5, 10]),
+                             np.array([1, 0.2]),
+                             np.array([2, 5]),
+                             np.array([[5/2, 5/5], 
+                                       [10/2, 10/5]]),
+                             np.array([
+                                 [[0, 0], [0, 0]],
+                                 [[(0.8/0.2)*5/2, (0.8/0.2)*5/5], [(0.8/0.2)*10/2, (0.8/0.2)*10/5]]
+                                 ])          
+                            )
+                          ])
+
+def test_calc_testing_simple_ph_time_params(fluences, duty_cycles, nums_pulses, exp_pulse_lengths, exp_abs_dwell_times):
+    obs_pulse_lengths, obs_abs_dwell_times = tcipd.calc_testing_simple_ph_time_params(fluences, duty_cycles, nums_pulses)
+    assert np.array_equal(obs_pulse_lengths, exp_pulse_lengths)
+    assert np.array_equal(obs_abs_dwell_times, exp_abs_dwell_times)
+
+@pytest.mark.parametrize("flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit, exp_testing_pe_array", [
+                            (np.array(['../iter', '../frascati']),
+                             np.array([[5, 6], [1, 2]]),
+                             np.array([2, 4]),
+                             np.array([[[0.3, 0.2], [0.1, 1]], [[0.5, 0.1], [0.4, 0.9]]]),
+                             'y',
+                             np.array([
+                                 [[
+                                     [{'type': 'pulse_entry', 
+                                     'pulse_length': 5, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.3, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 6, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 0.2, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}], 
+
+                                     [{'type': 'pulse_entry', 
+                                     'pulse_length': 1, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.1, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+                                     
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 2, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 1, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}]],
+
+                                     [[{'type': 'pulse_entry', 
+                                     'pulse_length': 5, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.5, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 6, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 0.1, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}],
+
+                                     [{'type': 'pulse_entry', 
+                                     'pulse_length': 1, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.4, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+                                     
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 2, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../iter', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 0.9, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}]]],
+
+
+
+                                     [[[{'type': 'pulse_entry', 
+                                     'pulse_length': 5, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.3, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 6, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 0.2, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}], 
+
+                                     [{'type': 'pulse_entry', 
+                                     'pulse_length': 1, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.1, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+                                     
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 2, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 1, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}]],
+
+                                     [[{'type': 'pulse_entry', 
+                                     'pulse_length': 5, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.5, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 6, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 0.1, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}],
+
+                                     [{'type': 'pulse_entry', 
+                                     'pulse_length': 1, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [2, 0.4, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'},
+                                     
+                                     {'type': 'pulse_entry', 
+                                     'pulse_length': 2, 
+                                     'pulse_length_unit': 'y',
+                                     'flux_filepath': '../frascati', 
+                                     'flux_norm': 1.0, 
+                                     'pulse_history': [4, 0.9, 'y'], 
+                                     'delay_dur': 0.0, 
+                                     'delay_dur_unit': 'y'}]]]
+                                     
+                                 ])
+                            )
+                            ])
+
+def test_populate_simple_child_dict(flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit, exp_testing_pe_array):
+    obs_testing_pe_array = tcipd.populate_simple_child_dict(flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit)
+    assert np.array_equal(exp_testing_pe_array, obs_testing_pe_array)

--- a/tools/test_testing_case_inp_params_to_dict.py
+++ b/tools/test_testing_case_inp_params_to_dict.py
@@ -26,7 +26,7 @@ import numpy as np
       'pulse_length_unit': 'y',
       'flux_filepath' : '../iter_flux',
       'flux_norm' : 0.3,
-      'pulse_history': [5, 10, 'm'],
+      'pulse_history': [(5, 10, 'm')],
       'delay_dur' : 0.0,
       'delay_dur_unit' : 's'},
       
@@ -35,7 +35,7 @@ import numpy as np
       'pulse_length_unit': 'y',
       'flux_filepath' : '../frascati_flux',
       'flux_norm' : 0.3,
-      'pulse_history': [5, 10, 'm'],
+      'pulse_history': [(5, 10, 'm')],
       'delay_dur' : 0.0,
       'delay_dur_unit' : 's'}
             ]

--- a/tools/test_testing_case_inp_params_to_dict.py
+++ b/tools/test_testing_case_inp_params_to_dict.py
@@ -1,183 +1,64 @@
-import numpy as np
 import pytest
 import testing_case_inp_params_to_dict as tcipd
+import numpy as np
 
-@pytest.mark.parametrize("fluences, duty_cycles, nums_pulses, exp_pulse_lengths, exp_abs_dwell_times", [
-                            (np.array([5, 10]),
-                             np.array([1, 0.2]),
-                             np.array([2, 5]),
-                             np.array([[5/2, 5/5], 
-                                       [10/2, 10/5]]),
-                             np.array([
-                                 [[0, 0], [0, 0]],
-                                 [[(0.8/0.2)*5/2, (0.8/0.2)*5/5], [(0.8/0.2)*10/2, (0.8/0.2)*10/5]]
-                                 ])          
-                            )
-                          ])
+@pytest.mark.parametrize("num_pulses, dwell_time, dwell_time_unit, min_on_time, rel_on_time_factors, " \
+                        "flux_norm_factors, flux_files, pulse_length_unit, exp_testing_child_dicts", [
+    (
+    5,
+    10,
+    'm',
+    1,
+    np.array([2, 4]),
+    np.array([1, 0.3]),
+    np.array(['../iter_flux', '../frascati_flux']),
+    'y',
+    np.array([
+        [
+            [
+            None,
+            None
+            ],
 
-def test_calc_testing_simple_ph_time_params(fluences, duty_cycles, nums_pulses, exp_pulse_lengths, exp_abs_dwell_times):
-    obs_pulse_lengths, obs_abs_dwell_times = tcipd.calc_testing_simple_ph_time_params(fluences, duty_cycles, nums_pulses)
-    assert np.array_equal(obs_pulse_lengths, exp_pulse_lengths)
-    assert np.array_equal(obs_abs_dwell_times, exp_abs_dwell_times)
+            [
+            {'type': 'pulse_entry',
+      'pulse_length' : 2,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../iter_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [5, 10, 'm'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'},
+      
+      {'type': 'pulse_entry',
+      'pulse_length' : 2,
+      'pulse_length_unit': 'y',
+      'flux_filepath' : '../frascati_flux',
+      'flux_norm' : 0.3,
+      'pulse_history': [5, 10, 'm'],
+      'delay_dur' : 0.0,
+      'delay_dur_unit' : 's'}
+            ]
+        ],
 
-@pytest.mark.parametrize("flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit, exp_testing_pe_array", [
-                            (np.array(['../iter', '../frascati']),
-                             np.array([[5, 6], [1, 2]]),
-                             np.array([2, 4]),
-                             np.array([[[0.3, 0.2], [0.1, 1]], [[0.5, 0.1], [0.4, 0.9]]]),
-                             'y',
-                             np.array([
-                                 [[
-                                     [{'type': 'pulse_entry', 
-                                     'pulse_length': 5, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.3, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
+        [
+            [
+            None,
+            None
+            ],
 
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 6, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 0.2, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}], 
+            [
+            None,
+            None
+            ]
+        ]
+      ])
+     )
+     ])
 
-                                     [{'type': 'pulse_entry', 
-                                     'pulse_length': 1, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.1, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-                                     
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 2, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 1, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}]],
-
-                                     [[{'type': 'pulse_entry', 
-                                     'pulse_length': 5, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.5, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 6, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 0.1, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}],
-
-                                     [{'type': 'pulse_entry', 
-                                     'pulse_length': 1, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.4, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-                                     
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 2, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../iter', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 0.9, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}]]],
-
-
-
-                                     [[[{'type': 'pulse_entry', 
-                                     'pulse_length': 5, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.3, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 6, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 0.2, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}], 
-
-                                     [{'type': 'pulse_entry', 
-                                     'pulse_length': 1, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.1, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-                                     
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 2, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 1, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}]],
-
-                                     [[{'type': 'pulse_entry', 
-                                     'pulse_length': 5, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.5, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 6, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 0.1, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}],
-
-                                     [{'type': 'pulse_entry', 
-                                     'pulse_length': 1, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [2, 0.4, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'},
-                                     
-                                     {'type': 'pulse_entry', 
-                                     'pulse_length': 2, 
-                                     'pulse_length_unit': 'y',
-                                     'flux_filepath': '../frascati', 
-                                     'flux_norm': 1.0, 
-                                     'pulse_history': [4, 0.9, 'y'], 
-                                     'delay_dur': 0.0, 
-                                     'delay_dur_unit': 'y'}]]]
-                                     
-                                 ])
-                            )
-                            ])
-
-def test_populate_simple_child_dict(flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit, exp_testing_pe_array):
-    obs_testing_pe_array = tcipd.populate_simple_child_dict(flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit)
-    assert np.array_equal(exp_testing_pe_array, obs_testing_pe_array)
+def test_write_testing_params_dict(num_pulses, dwell_time, dwell_time_unit, min_on_time,
+                                   rel_on_time_factors, flux_norm_factors, flux_files, pulse_length_unit, exp_testing_child_dicts):
+    obs_testing_child_dicts = tcipd.write_testing_params_dict(num_pulses, dwell_time, dwell_time_unit, 
+                                                                                   min_on_time, rel_on_time_factors, flux_norm_factors, 
+                                                                                   flux_files, pulse_length_unit)
+    assert np.array_equal(obs_testing_child_dicts, exp_testing_child_dicts)

--- a/tools/testing_case_inp_params_to_dict.py
+++ b/tools/testing_case_inp_params_to_dict.py
@@ -1,68 +1,54 @@
 import numpy as np
 from itertools import product
 
-'''
-The following dictionary (child_dict) is the representative data structure used to
-store and access pulse history-related information for ALARA simulations. This script
-populates this dictionary using user-specified information about the pulse history.
 
-Because this script is intended to store information for the testing cases,
-flux variation is introduced through duty cycles, and the flux normalization
-factor is taken to be 1.
+def write_testing_params_dict(num_pulses, dwell_time, min_on_time, rel_on_time_factors,
+                               flux_norm_factors, flux_files, time_unit):
+    """
+    This function takes a series of input parameters and converts them into a dictionary with a single
+    pulse entry with a single-level pulse history. A separate dictionary for each viable combination of 
+    input parameters is constructed, and each dictionary is stored in a numpy array of
+    shape len(rel_on_time_factors) x len(flux_norm_factors) x len(flux_files).
 
-  {'type': 'pulse_entry',
-      'pulse_length': (float),
-      'pulse_length_unit': (str),
-      'flux_filepath' : (str),
-      'flux_norm' : (float),
-      'pulse_history': (iterable of (int, float, str)),
-      'delay_dur' : (float),
-      'delay_dur_unit': (str)
-  }
-'''
-def calc_testing_simple_ph_time_params(fluences, duty_cycles, nums_pulses):
-    '''
-    Calculates the pulse lengths and pulse dwell times given a set of fluences/on-times,
-    duty cycles, and pulse numbers. These parameters are calculated for a single-level
-    pulse history.
-    input:
-    :param: fluences: iterable of times (float) where the system experiences nonzero flux
-    :param: duty_cycles: iterable of duty cycles (float), defined as pulse length / (pulse length + dwell time)
-    For each value, 0 < duty cycle <= 1
-    :param: nums_pulses: iterable of the number (int) of pulses the on-time is divided into
+    The total amount of fluence is defined by the product of the minimum on-time
+    and the maximum flux magnitude. If a combination of on-time and flux scaling factors results in
+    the total fluence being exceeded, the corresponding entry in the numpy array of dictionaries is
+    set to None.
+    [
+    {'type': 'pulse_entry',
+        'pulse_length': (float),
+        'pulse_length_unit': (str),
+        'flux_filepath' : (str),
+        'flux_norm' : (float),
+        'pulse_history': (iterable of (int, float, str)),
+        'delay_dur' : (float),
+        'delay_dur_unit': (str)
+    }
+    ]
+    :param: nums_pulses (number of pulses (int) in the single-level pulse history)
+    :param: dwell_time (off-time (float) between subsequent pulses)
+    :param: min_on_time (minimum total amount of time (float) during which the flux is nonzero)
+    :param: rel_on_time_factors (iterable of factors (float) that scale the minimum on-time)
+    :param: flux_norm_factors (iterable of factors (float) that scale the maximum flux magnitude)
+    :param: flux_files (iterable of paths (str) to flux files)
+    :param: time_unit (unit (str) of pulse length and dwell time)
+    """
+    testing_child_dicts = np.ndarray((len(rel_on_time_factors), len(flux_norm_factors), len(flux_files)), dtype=object)
+    for (rel_on_time_factor_idx, rel_on_time_factor), (flux_norm_factor_idx, flux_norm_factor), (flux_file_idx, flux_file) in product(
+                enumerate(rel_on_time_factors),
+                enumerate(flux_norm_factors),
+                enumerate(flux_files)):
+        if rel_on_time_factor * flux_norm_factor > 1:
+            testing_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
+        else:
+            testing_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = {
+                                        'type': 'pulse_entry',
+                                        'pulse_length': min_on_time * rel_on_time_factor,
+                                        'pulse_length_unit': time_unit,
+                                        'flux_filepath': flux_file,
+                                        'flux_norm': flux_norm_factor,
+                                        'pulse_history': [num_pulses, dwell_time, time_unit],
+                                        'delay_dur': 0.0,
+                                        'delay_dur_unit': 's'}
+    return testing_child_dicts
 
-    output:
-    pulse_lengths: 2D numpy array of shape (len(fluences), len(nums_pulses))
-    abs_dwell_times: 3D numpy array of shape (len(duty_cycles), len(fluences), len(nums_pulses))
-    '''
-    pulse_lengths = np.outer(fluences, 1/nums_pulses)
-    rel_dwell_times = (1 - duty_cycles) / duty_cycles
-    abs_dwell_times = np.multiply.outer(rel_dwell_times, pulse_lengths)
-    return pulse_lengths, abs_dwell_times
-
-def populate_simple_child_dict(flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit):
-    '''
-    Populates the child dictionary structure using the pulse lengths and dwell times calculated in
-    calc_testing_simple_ph_time_params().
-    input:
-    flux_filepaths: iterable of paths (str) to files containing flux data
-    time_unit: unit (str) of fluence time
-
-    output:
-    testing_pe_array: 4D numpy array of shape (len(flux_filepaths), len(duty_cycles), len(fluences), len(nums_pulses))
-    '''
-    testing_pe_array = np.empty((len(flux_filepaths),) + abs_dwell_times.shape, dtype=object)
-    for (flux_idx, flux_filepath), ((duty_cycle_idx, fluence_idx, num_pulse_idx), abs_dwell_time) in product(
-        enumerate(flux_filepaths), np.ndenumerate(abs_dwell_times)
-        ):
-        testing_pe_array[flux_idx, duty_cycle_idx, fluence_idx, num_pulse_idx] = {
-        'type': 'pulse_entry',
-        'pulse_length': pulse_lengths[fluence_idx, num_pulse_idx],
-        'pulse_length_unit': time_unit,
-        'flux_filepath' : flux_filepath,
-        'flux_norm': 1.0,
-        'pulse_history': [nums_pulses[num_pulse_idx], abs_dwell_time, time_unit],
-        'delay_dur' : 0.0,
-        'delay_dur_unit': time_unit
-        }
-    return testing_pe_array    

--- a/tools/testing_case_inp_params_to_dict.py
+++ b/tools/testing_case_inp_params_to_dict.py
@@ -2,8 +2,8 @@ import numpy as np
 from itertools import product
 
 
-def write_testing_params_dict(num_pulses, dwell_time, min_on_time, rel_on_time_factors,
-                               flux_norm_factors, flux_files, time_unit):
+def write_testing_params_dict(num_pulses, dwell_time, dwell_time_unit, min_on_time, rel_on_time_factors,
+                               flux_norm_factors, flux_files, pulse_length_unit):
     """
     This function takes a series of input parameters and converts them into a dictionary with a single
     pulse entry with a single-level pulse history. A separate dictionary for each viable combination of 
@@ -27,11 +27,12 @@ def write_testing_params_dict(num_pulses, dwell_time, min_on_time, rel_on_time_f
     ]
     :param: nums_pulses (number of pulses (int) in the single-level pulse history)
     :param: dwell_time (off-time (float) between subsequent pulses)
+    :param: dwell_time_unit (unit (str) of the dwell time)
     :param: min_on_time (minimum total amount of time (float) during which the flux is nonzero)
     :param: rel_on_time_factors (iterable of factors (float) that scale the minimum on-time)
     :param: flux_norm_factors (iterable of factors (float) that scale the maximum flux magnitude)
     :param: flux_files (iterable of paths (str) to flux files)
-    :param: time_unit (unit (str) of pulse length and dwell time)
+    :param: pulse_length_unit (unit (str) of the pulse length)
     """
     testing_child_dicts = np.ndarray((len(rel_on_time_factors), len(flux_norm_factors), len(flux_files)), dtype=object)
     for (rel_on_time_factor_idx, rel_on_time_factor), (flux_norm_factor_idx, flux_norm_factor), (flux_file_idx, flux_file) in product(
@@ -44,11 +45,10 @@ def write_testing_params_dict(num_pulses, dwell_time, min_on_time, rel_on_time_f
             testing_child_dicts[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = {
                                         'type': 'pulse_entry',
                                         'pulse_length': min_on_time * rel_on_time_factor,
-                                        'pulse_length_unit': time_unit,
+                                        'pulse_length_unit': pulse_length_unit,
                                         'flux_filepath': flux_file,
                                         'flux_norm': flux_norm_factor,
-                                        'pulse_history': [num_pulses, dwell_time, time_unit],
+                                        'pulse_history': [(num_pulses, dwell_time, dwell_time_unit)],
                                         'delay_dur': 0.0,
                                         'delay_dur_unit': 's'}
     return testing_child_dicts
-

--- a/tools/testing_case_inp_params_to_dict.py
+++ b/tools/testing_case_inp_params_to_dict.py
@@ -1,0 +1,68 @@
+import numpy as np
+from itertools import product
+
+'''
+The following dictionary (child_dict) is the representative data structure used to
+store and access pulse history-related information for ALARA simulations. This script
+populates this dictionary using user-specified information about the pulse history.
+
+Because this script is intended to store information for the testing cases,
+flux variation is introduced through duty cycles, and the flux normalization
+factor is taken to be 1.
+
+  {'type': 'pulse_entry',
+      'pulse_length': (float),
+      'pulse_length_unit': (str),
+      'flux_filepath' : (str),
+      'flux_norm' : (float),
+      'pulse_history': (iterable of (int, float, str)),
+      'delay_dur' : (float),
+      'delay_dur_unit': (str)
+  }
+'''
+def calc_testing_simple_ph_time_params(fluences, duty_cycles, nums_pulses):
+    '''
+    Calculates the pulse lengths and pulse dwell times given a set of fluences/on-times,
+    duty cycles, and pulse numbers. These parameters are calculated for a single-level
+    pulse history.
+    input:
+    :param: fluences: iterable of times (float) where the system experiences nonzero flux
+    :param: duty_cycles: iterable of duty cycles (float), defined as pulse length / (pulse length + dwell time)
+    For each value, 0 < duty cycle <= 1
+    :param: nums_pulses: iterable of the number (int) of pulses the on-time is divided into
+
+    output:
+    pulse_lengths: 2D numpy array of shape (len(fluences), len(nums_pulses))
+    abs_dwell_times: 3D numpy array of shape (len(duty_cycles), len(fluences), len(nums_pulses))
+    '''
+    pulse_lengths = np.outer(fluences, 1/nums_pulses)
+    rel_dwell_times = (1 - duty_cycles) / duty_cycles
+    abs_dwell_times = np.multiply.outer(rel_dwell_times, pulse_lengths)
+    return pulse_lengths, abs_dwell_times
+
+def populate_simple_child_dict(flux_filepaths, pulse_lengths, nums_pulses, abs_dwell_times, time_unit):
+    '''
+    Populates the child dictionary structure using the pulse lengths and dwell times calculated in
+    calc_testing_simple_ph_time_params().
+    input:
+    flux_filepaths: iterable of paths (str) to files containing flux data
+    time_unit: unit (str) of fluence time
+
+    output:
+    testing_pe_array: 4D numpy array of shape (len(flux_filepaths), len(duty_cycles), len(fluences), len(nums_pulses))
+    '''
+    testing_pe_array = np.empty((len(flux_filepaths),) + abs_dwell_times.shape, dtype=object)
+    for (flux_idx, flux_filepath), ((duty_cycle_idx, fluence_idx, num_pulse_idx), abs_dwell_time) in product(
+        enumerate(flux_filepaths), np.ndenumerate(abs_dwell_times)
+        ):
+        testing_pe_array[flux_idx, duty_cycle_idx, fluence_idx, num_pulse_idx] = {
+        'type': 'pulse_entry',
+        'pulse_length': pulse_lengths[fluence_idx, num_pulse_idx],
+        'pulse_length_unit': time_unit,
+        'flux_filepath' : flux_filepath,
+        'flux_norm': 1.0,
+        'pulse_history': [nums_pulses[num_pulse_idx], abs_dwell_time, time_unit],
+        'delay_dur' : 0.0,
+        'delay_dur_unit': time_unit
+        }
+    return testing_pe_array    


### PR DESCRIPTION
Makes an array of dictionaries, where each dictionary contains the information needed to describe a single pulse entry. This is currently set up to work for a single-level pulse history that is referenced by a single, one-line schedule.

This script is intended to set up data for the testing cases by introducing some variation away from the training data, in particular by using more than 1 pulse in the history and/or using different scaling factors for the relative flux magnitudes.

The dwell time is used as an input parameter for `write_inp_params_to_dict()`, with the assumption that the value used for the dwell time may be derived from a variety of methods (duty cycles, random number generation, etc.). The functions used to generate the values of the dwell time will be added to a different script in order to separate the tasks of writing the data to a dictionary and formulating the dwell time as needed.

addresses #37