### PR TITLE
Make a table of flux spectra

### DIFF
--- a/tools/make_flux_table.py
+++ b/tools/make_flux_table.py
@@ -1,0 +1,29 @@
+def create_flux_table(cur):
+    """
+    Creates a sqlite table called flux_spectra using a provided sqlite cursor object.
+    :param: cur (sqlite cursor object)
+    """
+    cur.execute("""CREATE TABLE IF NOT EXISTS flux_spectra (
+    flux_spec_shape_id INT PRIMARY KEY,
+    flux_file TEXT,
+    flux_spectrum TEXT,                           
+    UNIQUE(flux_file, flux_spectrum)
+    )
+    """
+    )
+  
+def populate_flux_table(cur, flux_data_dict):
+    """
+    Populates a flux table that has already been initialized with data used to identify each spectrum.
+    :param: cur (sqlite cursor object that points to a connection with a table called flux_spectra)
+    :param: flux_data_dict (dictionary with the form below)
+    {
+    'flux_spec_shape_id' : (int, identifier for each flux file/spectrum),
+    'flux_file' : (str, path to file containing flux spectrum),
+    'flux_spectrum' : (str, iterable of flux values for some group structure, stored as text)
+    }
+    """
+    cur.executemany(
+            "INSERT INTO flux_spectra (flux_spec_shape_id, flux_file, flux_spectrum) VALUES (?, ?, ?)",
+            list(zip(*flux_data_dict.values())),
+    )

--- a/tools/make_flux_table.py
+++ b/tools/make_flux_table.py
@@ -2,9 +2,11 @@ def create_flux_table(cur):
     """
     Creates a sqlite table called flux_spectra using a provided sqlite cursor object.
     :param: cur (sqlite cursor object)
+
+    flux_spec_shape_id is an alias for the table's internal rowid column
     """
     cur.execute("""CREATE TABLE IF NOT EXISTS flux_spectra (
-    flux_spec_shape_id INT PRIMARY KEY,
+    flux_spec_shape_id INTEGER PRIMARY KEY,
     flux_file TEXT,
     flux_spectrum TEXT,                           
     UNIQUE(flux_file, flux_spectrum)
@@ -18,12 +20,11 @@ def populate_flux_table(cur, flux_data_dict):
     :param: cur (sqlite cursor object that points to a connection with a table called flux_spectra)
     :param: flux_data_dict (dictionary with the form below)
     {
-    'flux_spec_shape_id' : (int, identifier for each flux file/spectrum),
     'flux_file' : (str, path to file containing flux spectrum),
     'flux_spectrum' : (str, iterable of flux values for some group structure, stored as text)
     }
     """
     cur.executemany(
-            "INSERT INTO flux_spectra (flux_spec_shape_id, flux_file, flux_spectrum) VALUES (?, ?, ?)",
+            "INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
             list(zip(*flux_data_dict.values())),
     )

--- a/tools/test_make_flux_table.py
+++ b/tools/test_make_flux_table.py
@@ -10,7 +10,6 @@ import numpy as np
         (
             sqlite3.connect("activation_results.db").cursor(),
             {
-                'flux_spec_shape_id' : [1,2],
                 'flux_file' : ['../fnsf', '../iter_dt'],
                 'flux_spectrum' : [json.dumps(np.array([3, 9, 12]).tolist()), json.dumps([5, 7, 11, 13, 25])]
             },
@@ -27,7 +26,6 @@ import numpy as np
                 """
             ),
             {
-                'flux_spec_shape_id': [3, 4],
                 'flux_file' : ['../fnsf', '../iter_dt'],
                 'flux_spectrum' : ['[3,9,12]', json.dumps([5, 7, 11, 13, 25])]
             },
@@ -42,6 +40,8 @@ def test_populate_flux_table(cur, flux_data_dict):
     cur.execute("BEGIN") # stops subsequent statements (e.g. CREATE TABLE) from being committed automatically
     mft.create_flux_table(cur)
     mft.populate_flux_table(cur, flux_data_dict)
+    id_rows = cur.execute("SELECT flux_spec_shape_id from flux_spectra").fetchall()
     rows = cur.execute("SELECT * from flux_spectra").fetchall()
-    assert len(rows) == len(flux_data_dict["flux_spec_shape_id"]) == len(flux_data_dict["flux_file"]) == len(flux_data_dict["flux_spectrum"])
+    assert len(rows) == len(flux_data_dict["flux_file"]) == len(flux_data_dict["flux_spectrum"])
+    assert id_rows[1][0] == 2
     cur.connection.close()

--- a/tools/test_make_flux_table.py
+++ b/tools/test_make_flux_table.py
@@ -1,7 +1,6 @@
 import pytest
 import make_flux_table as mft
 import sqlite3
-import uuid
 import json
 import numpy as np
 
@@ -20,7 +19,7 @@ import numpy as np
             sqlite3.connect(":memory:").cursor().execute(
                 """
                 CREATE TABLE flux_spectra (
-                flux_spec_shape_id INT PRIMARY KEY,
+                flux_spec_shape_id INTEGER PRIMARY KEY,
                 flux_file TEXT,
                 flux_spectrum TEXT,
                 UNIQUE(flux_file, flux_spectrum)
@@ -28,9 +27,9 @@ import numpy as np
                 """
             ),
             {
-                'flux_spec_shape_id': [str(uuid.uuid4()), 5],
+                'flux_spec_shape_id': [3, 4],
                 'flux_file' : ['../fnsf', '../iter_dt'],
-                'flux_spectrum' : [json.dumps(np.array([3, 9, 12]).tolist()), json.dumps([5, 7, 11, 13, 25])]
+                'flux_spectrum' : ['[3,9,12]', json.dumps([5, 7, 11, 13, 25])]
             },
         ),
     ],

--- a/tools/test_make_flux_table.py
+++ b/tools/test_make_flux_table.py
@@ -1,0 +1,48 @@
+import pytest
+import make_flux_table as mft
+import sqlite3
+import uuid
+import json
+import numpy as np
+
+@pytest.mark.parametrize(
+    "cur,flux_data_dict",
+    [
+        (
+            sqlite3.connect("activation_results.db").cursor(),
+            {
+                'flux_spec_shape_id' : [1,2],
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : [json.dumps(np.array([3, 9, 12]).tolist()), json.dumps([5, 7, 11, 13, 25])]
+            },
+        ),
+        (
+            sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INT PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ),
+            {
+                'flux_spec_shape_id': [str(uuid.uuid4()), 5],
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : [json.dumps(np.array([3, 9, 12]).tolist()), json.dumps([5, 7, 11, 13, 25])]
+            },
+        ),
+    ],
+)
+def test_populate_flux_table(cur, flux_data_dict):
+    """
+    Ensure that the "INSERT into" statement was executed successfully,
+    without committing the operation into the actual database.
+    """
+    cur.execute("BEGIN") # stops subsequent statements (e.g. CREATE TABLE) from being committed automatically
+    mft.create_flux_table(cur)
+    mft.populate_flux_table(cur, flux_data_dict)
+    rows = cur.execute("SELECT * from flux_spectra").fetchall()
+    assert len(rows) == len(flux_data_dict["flux_spec_shape_id"]) == len(flux_data_dict["flux_file"]) == len(flux_data_dict["flux_spectrum"])
+    cur.connection.close()


### PR DESCRIPTION
In this script a sqlite table is created to keep track of different flux spectra using integer ID values. The ID value of each spectrum is simply the internal `rowid` of the sqlite table, with `flux_spec_shape_id` being an alias for the `rowid`.