### PR TITLE
Add script to query SQLite database

### DIFF
--- a/tools/query_sqlite_db.py
+++ b/tools/query_sqlite_db.py
@@ -1,0 +1,28 @@
+import json
+
+def find_flux_spec_shape_id(sqlite_conn, column_name, row_value):
+    '''
+    Assuming that a table called flux_spectra exists in the database, find
+    the id of the desired flux spectrum from the table. Assumes that the
+    spectral data in the table is stored in json/text format.
+    :param: sqlite_conn (sqlite3 connection object)
+    :param: column_name (str, one of "flux_spectrum" or "flux_file")
+    :param: row_value: value taken on by either the flux_spectrum or flux_file columns,
+                        one of the following:
+        - flux spectrum shape (iterable, normalized flux spectrum with the number of entries 
+                            being the number of groups in the structure)
+        - flux file (str, path to file containing flux spectrum)
+    '''
+    if column_name == 'flux_spectrum':
+        db_value = json.dumps(row_value.tolist()) if hasattr(row_value, "tolist") else json.dumps(row_value)
+        result = sqlite_conn.execute(
+        f"SELECT flux_spec_shape_id FROM flux_spectra WHERE json({column_name}) = json(?)",
+        (db_value,)
+        )
+    elif column_name == 'flux_file':
+        result = sqlite_conn.execute(
+        f"SELECT flux_spec_shape_id FROM flux_spectra WHERE {column_name} = ?",
+        (row_value,)
+        )
+    flux_spec_shape_id = result.fetchone()[0]
+    return flux_spec_shape_id

--- a/tools/test_query_sqlite_db.py
+++ b/tools/test_query_sqlite_db.py
@@ -1,0 +1,50 @@
+import pytest
+import query_sqlite_db as qsd
+import sqlite3
+import json
+
+@pytest.mark.parametrize("sqlite_conn, column_name, row_value, exp_flux_spec_shape_id", [
+    (
+        sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9,12]', json.dumps([5,7, 11, 13, 25])]
+            }.values()))).connection,
+        'flux_spectrum',
+        [3,9, 12],
+        1
+    ),
+
+    (
+        sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9, 12]', json.dumps([5, 7, 11, 13, 25])]
+            }.values()))).connection,
+        'flux_file',
+        '../iter_dt',
+        2
+    )
+     ])
+
+def test_find_flux_spec_shape_id(sqlite_conn, column_name, row_value, exp_flux_spec_shape_id):
+    obs_flux_spec_shape_id = qsd.find_flux_spec_shape_id(sqlite_conn, column_name, row_value)
+    assert obs_flux_spec_shape_id == exp_flux_spec_shape_id


### PR DESCRIPTION
This script contains a method to find the id of the flux spectrum shape from the flux spectra table in the database. Either the path to the flux file or the spectrum shape itself may be used for the search.