### PR TITLE
Add function to make training filenames

### DIFF
--- a/tools/make_training_filenames.py
+++ b/tools/make_training_filenames.py
@@ -20,9 +20,8 @@ def make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_uni
     filenames = np.empty((len(min_on_times),) + training_inp_info.shape, dtype=object)
     for (min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx), _ in np.ndenumerate(filenames):
         entry = training_inp_info[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx]
-        if entry == None:
+        if entry is None:
             filenames[min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
-            continue
         else:
             rel_on_time_factor, flux_norm_factor, flux_file = entry
             flux_id = qsd.find_flux_spec_shape_id(sqlite_conn, "flux_file", flux_file)

--- a/tools/make_training_filenames.py
+++ b/tools/make_training_filenames.py
@@ -1,0 +1,32 @@
+import query_sqlite_db as qsd
+import numpy as np
+
+
+'''
+For the training set, where each simulation runs a single pulse with no dwell times, variation is introduced with
+the maximum flux magnitude, minimum irradiation time, and scaling factors of flux magnitude and irradiation time.
+This is repeated for a series of flux spectra.
+'''
+
+def make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_unit):
+    """
+    :param: training_inp_info (3D numpy array where each dimension corresponds to
+    relative fluence factors (float), flux normalization factors (float), and paths to flux files (str), respectively)
+    Each entry of training_inp_info is a 3-tuple of (relative fluence factor, flux normalization factor, flux file)
+    :param: sqlite_conn (SQLite connection object to database containing flux table)
+    :param: min_on_times (iterable of minimum steady-state operational times used to define the total fluence)
+    :param: time_unit (unit (str) of min_on_times)
+    """
+    filenames = np.empty((len(min_on_times),) + training_inp_info.shape, dtype=object)
+    for (min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx), _ in np.ndenumerate(filenames):
+        entry = training_inp_info[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx]
+        if entry == None:
+            filenames[min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
+            continue
+        else:
+            rel_on_time_factor, flux_norm_factor, flux_file = entry
+            flux_id = qsd.find_flux_spec_shape_id(sqlite_conn, "flux_file", flux_file)
+            filename = f"{flux_id}_{flux_norm_factor}_{min_on_times[min_on_time_idx]}{time_unit}_{rel_on_time_factor}"
+            filenames[min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = filename
+    return filenames
+

--- a/tools/query_sqlite_db.py
+++ b/tools/query_sqlite_db.py
@@ -1,0 +1,28 @@
+import json
+
+def find_flux_spec_shape_id(sqlite_conn, column_name, row_value):
+    '''
+    Assuming that a table called flux_spectra exists in the database, find
+    the id of the desired flux spectrum from the table. Assumes that the
+    spectral data in the table is stored in json/text format.
+    :param: sqlite_conn (sqlite3 connection object)
+    :param: column_name (str, one of "flux_spectrum" or "flux_file")
+    :param: row_value: value taken on by either the flux_spectrum or flux_file columns,
+                        one of the following:
+        - flux spectrum shape (iterable, normalized flux spectrum with the number of entries 
+                            being the number of groups in the structure)
+        - flux file (str, path to file containing flux spectrum)
+    '''
+    if column_name == 'flux_spectrum':
+        db_value = json.dumps(row_value.tolist()) if hasattr(row_value, "tolist") else json.dumps(row_value)
+        result = sqlite_conn.execute(
+        f"SELECT flux_spec_shape_id FROM flux_spectra WHERE json({column_name}) = json(?)",
+        (db_value,)
+        )
+    elif column_name == 'flux_file':
+        result = sqlite_conn.execute(
+        f"SELECT flux_spec_shape_id FROM flux_spectra WHERE {column_name} = ?",
+        (row_value,)
+        )
+    flux_spec_shape_id = result.fetchone()[0]
+    return flux_spec_shape_id

--- a/tools/test_make_training_filenames.py
+++ b/tools/test_make_training_filenames.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+import sqlite3
+import json
+import make_training_inps as mti
+
+@pytest.mark.parametrize("training_inp_info, sqlite_conn, min_on_times, time_unit, exp_filenames", [
+    (
+np.array([
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            (2, 0.3, '../iter_flux'),
+      
+      (2, 0.3, '../frascati_flux')
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+      ], dtype=object),
+      sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9,12]', json.dumps([5,7, 11, 13, 25])]
+            }.values()))).connection,
+        [10, 20],
+        's',
+        np.array([[
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"1_0.3_10_'s'_2",
+      
+      f"2_0.3_10_'s'_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ],
+    [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"1_0.3_20_'s'_2",
+      
+      f"2_0.3_20_'s'_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ]
+    ], dtype=object)
+)])
+
+def test_make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_unit, exp_filenames):
+    obs_filenames = mti.make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_unit)
+    assert obs_filenames == exp_filenames

--- a/tools/test_make_training_filenames.py
+++ b/tools/test_make_training_filenames.py
@@ -1,8 +1,7 @@
 import pytest
 import numpy as np
 import sqlite3
-import json
-import make_training_inps as mti
+import make_training_filenames as mtf
 
 @pytest.mark.parametrize("training_inp_info, sqlite_conn, min_on_times, time_unit, exp_filenames", [
     (
@@ -14,9 +13,9 @@ np.array([
             ],
 
             [
-            (2, 0.3, '../iter_flux'),
+            (2, 0.3, '../fnsf'),
       
-      (2, 0.3, '../frascati_flux')
+      (2, 0.3, '../iter_dt')
             ]
         ],
 
@@ -44,7 +43,7 @@ np.array([
             ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
             list(zip(*{
                 'flux_file' : ['../fnsf', '../iter_dt'],
-                'flux_spectrum' : ['[3, 9,12]', json.dumps([5,7, 11, 13, 25])]
+                'flux_spectrum' : ['[3, 9,12]', '[5,7, 11, 13, 25]']
             }.values()))).connection,
         [10, 20],
         's',
@@ -56,9 +55,9 @@ np.array([
             ],
 
             [
-            f"1_0.3_10_'s'_2",
+            "1_0.3_10s_2",
       
-      f"2_0.3_10_'s'_2"
+      "2_0.3_10s_2"
             ]
         ],
 
@@ -82,9 +81,9 @@ np.array([
             ],
 
             [
-            f"1_0.3_20_'s'_2",
+            "1_0.3_20s_2",
       
-      f"2_0.3_20_'s'_2"
+      "2_0.3_20s_2"
             ]
         ],
 
@@ -104,5 +103,5 @@ np.array([
 )])
 
 def test_make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_unit, exp_filenames):
-    obs_filenames = mti.make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_unit)
-    assert obs_filenames == exp_filenames
+    obs_filenames = mtf.make_filename_strings(training_inp_info, sqlite_conn, min_on_times, time_unit)
+    assert np.array_equal(obs_filenames, exp_filenames)

--- a/tools/test_query_sqlite_db.py
+++ b/tools/test_query_sqlite_db.py
@@ -1,0 +1,50 @@
+import pytest
+import query_sqlite_db as qsd
+import sqlite3
+import json
+
+@pytest.mark.parametrize("sqlite_conn, column_name, row_value, exp_flux_spec_shape_id", [
+    (
+        sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9,12]', json.dumps([5,7, 11, 13, 25])]
+            }.values()))).connection,
+        'flux_spectrum',
+        [3,9, 12],
+        1
+    ),
+
+    (
+        sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9, 12]', json.dumps([5, 7, 11, 13, 25])]
+            }.values()))).connection,
+        'flux_file',
+        '../iter_dt',
+        2
+    )
+     ])
+
+def test_find_flux_spec_shape_id(sqlite_conn, column_name, row_value, exp_flux_spec_shape_id):
+    obs_flux_spec_shape_id = qsd.find_flux_spec_shape_id(sqlite_conn, column_name, row_value)
+    assert obs_flux_spec_shape_id == exp_flux_spec_shape_id


### PR DESCRIPTION
Makes a function to create filenames for training data input files, based on the expected structure of `training_inp_info` from `training_inp_params_to_dict.py` (#91).