### PR TITLE
Make filenames for simple testing cases

### DIFF
--- a/tools/make_testing_filenames.py
+++ b/tools/make_testing_filenames.py
@@ -1,0 +1,27 @@
+import numpy as np
+import query_sqlite_db as qsd
+
+def make_single_level_ph_filename_strings(max_fluence_factors, sqlite_conn, nums_pulses, dwell_times, min_on_times, on_time_unit, dwell_time_unit):
+    """
+    Creates filenames for pulse histories with a single level.
+    :param: max_fluence_factors (3D numpy array where each dimension corresponds to
+    relative fluence factors (float), flux normalization factors (float), and paths to flux files (str), respectively)
+    Each entry of max_fluence_factors is a 3-tuple of (relative fluence factor, flux normalization factor, flux file)
+    :param: sqlite_conn (SQLite connection object to database containing flux table)
+    :param: nums_pulses (iterable of number of pulses in each single-level pulse history)
+    :param: dwell_times (iterable of dwell times between subsequent pulses, where each dwell time is for each single-level pulse history)
+    :param: min_on_times (iterable of minimum steady-state operational times used to define the total fluence)
+    :param: on_time_unit (unit (str) of min_on_times)
+    :param: dwell_time_unit (unit (str) of dwell_times)
+    """
+    filenames = np.empty((len(min_on_times), len(nums_pulses), len(dwell_times)) + max_fluence_factors.shape, dtype=object)
+    for (num_pulse_idx, dwell_time_idx, min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx), _ in np.ndenumerate(filenames):
+        entry = max_fluence_factors[rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx]
+        if entry is None:
+            filenames[num_pulse_idx, dwell_time_idx, min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = None
+        else:
+            rel_on_time_factor, flux_norm_factor, flux_file = entry
+            flux_id = qsd.find_flux_spec_shape_id(sqlite_conn, "flux_file", flux_file)
+            filename = f"{nums_pulses[num_pulse_idx]}_{dwell_times[dwell_time_idx]}{dwell_time_unit}_{flux_id}_{flux_norm_factor}_{min_on_times[min_on_time_idx]}{on_time_unit}_{rel_on_time_factor}"
+            filenames[num_pulse_idx, dwell_time_idx, min_on_time_idx, rel_on_time_factor_idx, flux_norm_factor_idx, flux_file_idx] = filename
+    return filenames

--- a/tools/query_sqlite_db.py
+++ b/tools/query_sqlite_db.py
@@ -1,0 +1,28 @@
+import json
+
+def find_flux_spec_shape_id(sqlite_conn, column_name, row_value):
+    '''
+    Assuming that a table called flux_spectra exists in the database, find
+    the id of the desired flux spectrum from the table. Assumes that the
+    spectral data in the table is stored in json/text format.
+    :param: sqlite_conn (sqlite3 connection object)
+    :param: column_name (str, one of "flux_spectrum" or "flux_file")
+    :param: row_value: value taken on by either the flux_spectrum or flux_file columns,
+                        one of the following:
+        - flux spectrum shape (iterable, normalized flux spectrum with the number of entries 
+                            being the number of groups in the structure)
+        - flux file (str, path to file containing flux spectrum)
+    '''
+    if column_name == 'flux_spectrum':
+        db_value = json.dumps(row_value.tolist()) if hasattr(row_value, "tolist") else json.dumps(row_value)
+        result = sqlite_conn.execute(
+        f"SELECT flux_spec_shape_id FROM flux_spectra WHERE json({column_name}) = json(?)",
+        (db_value,)
+        )
+    elif column_name == 'flux_file':
+        result = sqlite_conn.execute(
+        f"SELECT flux_spec_shape_id FROM flux_spectra WHERE {column_name} = ?",
+        (row_value,)
+        )
+    flux_spec_shape_id = result.fetchone()[0]
+    return flux_spec_shape_id

--- a/tools/test_make_testing_filenames.py
+++ b/tools/test_make_testing_filenames.py
@@ -1,0 +1,274 @@
+import pytest
+import sqlite3
+import numpy as np
+import make_testing_filenames as mtf
+
+@pytest.mark.parametrize("training_inp_info, sqlite_conn, nums_pulses, dwell_times, min_on_times, on_time_unit, dwell_time_unit, exp_filenames", [
+    (
+np.array([
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            (2, 0.3, '../fnsf'),
+      
+      (2, 0.3, '../iter_dt')
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+      ], dtype=object),
+      sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9,12]', '[5,7, 11, 13, 25]']
+            }.values()))).connection,
+        [2, 5],
+        [0.2, 0.5],   
+        [10, 20],
+        'y',
+        's',
+        np.array([[[[
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"2_0.2s_1_0.3_10y_2",
+      
+      f"2_0.2s_2_0.3_10y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ],
+    [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"2_0.2s_1_0.3_20y_2",
+      
+      f"2_0.2s_2_0.3_20y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ]
+    ],
+    [
+        [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"2_0.5s_1_0.3_10y_2",
+      
+      f"2_0.5s_2_0.3_10y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ],
+    [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"2_0.5s_1_0.3_20y_2",
+      
+      f"2_0.5s_2_0.3_20y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ]
+    ]
+    ],
+    [[[
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"5_0.2s_1_0.3_10y_2",
+      
+      f"5_0.2s_2_0.3_10y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ],
+    [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"5_0.2s_1_0.3_20y_2",
+      
+      f"5_0.2s_2_0.3_20y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ]
+    ],
+    [
+        [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"5_0.5s_1_0.3_10y_2",
+      
+      f"5_0.5s_2_0.3_10y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ],
+    [
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            f"5_0.5s_1_0.3_20y_2",
+      
+      f"5_0.5s_2_0.3_20y_2"
+            ]
+        ],
+
+        [
+            [
+            None,
+            None
+            ],
+
+            [
+            None,
+            None
+            ]
+        ]
+    ]
+    ]
+    ]
+    ], dtype=object)
+)])
+
+def test_make_filename_strings(training_inp_info, sqlite_conn, nums_pulses, dwell_times, min_on_times, on_time_unit, dwell_time_unit, exp_filenames):
+    obs_filenames = mtf.make_single_level_ph_filename_strings(training_inp_info, sqlite_conn, nums_pulses, dwell_times, min_on_times, on_time_unit, dwell_time_unit)
+    assert np.array_equal(obs_filenames, exp_filenames)

--- a/tools/test_query_sqlite_db.py
+++ b/tools/test_query_sqlite_db.py
@@ -1,0 +1,50 @@
+import pytest
+import query_sqlite_db as qsd
+import sqlite3
+import json
+
+@pytest.mark.parametrize("sqlite_conn, column_name, row_value, exp_flux_spec_shape_id", [
+    (
+        sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9,12]', json.dumps([5,7, 11, 13, 25])]
+            }.values()))).connection,
+        'flux_spectrum',
+        [3,9, 12],
+        1
+    ),
+
+    (
+        sqlite3.connect(":memory:").cursor().execute(
+                """
+                CREATE TABLE flux_spectra (
+                flux_spec_shape_id INTEGER PRIMARY KEY,
+                flux_file TEXT,
+                flux_spectrum TEXT,
+                UNIQUE(flux_file, flux_spectrum)
+                )
+                """
+            ).executemany("INSERT INTO flux_spectra (flux_file, flux_spectrum) VALUES (?, ?)",
+            list(zip(*{
+                'flux_file' : ['../fnsf', '../iter_dt'],
+                'flux_spectrum' : ['[3, 9, 12]', json.dumps([5, 7, 11, 13, 25])]
+            }.values()))).connection,
+        'flux_file',
+        '../iter_dt',
+        2
+    )
+     ])
+
+def test_find_flux_spec_shape_id(sqlite_conn, column_name, row_value, exp_flux_spec_shape_id):
+    obs_flux_spec_shape_id = qsd.find_flux_spec_shape_id(sqlite_conn, column_name, row_value)
+    assert obs_flux_spec_shape_id == exp_flux_spec_shape_id


### PR DESCRIPTION
Adds a function that creates filename strings for simple (single-level ph) testing cases, using the number of pulses, dwell time, and steady state operational times as input parameters.